### PR TITLE
Umalator skill list to automatically select all text when opened

### DIFF
--- a/components/SkillList.tsx
+++ b/components/SkillList.tsx
@@ -496,7 +496,10 @@ export function SkillList(props) {
 	const [searchText, setSearchText] = useState('');
 
 	useEffect(function () {
-		if (props.isOpen && searchInput.current) searchInput.current.select();
+		if (props.isOpen && searchInput.current) {
+			searchInput.current.focus();
+			searchInput.current.select();
+		}
 	}, [props.isOpen]);
 	
 	const selectedMap = new Map(Array.from(props.selected).map(id => [skillmeta(id).groupId, id]));


### PR DESCRIPTION
This is about the issue #1 I created.
I should've created the pull request from the start.

When trying to add multiple skills, it would be helpful for the search text of the skill list to be automatically selected so you can start to type a new search without having to select all the text while still preserving the previous search.