### PR TITLE
Global Version Umamusume Track Adaptation

### DIFF
--- a/umalator-global/course_data.json
+++ b/umalator-global/course_data.json
@@ -1,1 +1,5953 @@
-{"10101":{"corners":[{"length":275,"start":400},{"length":275,"start":675}],"course":1,"courseSetStatus":[],"distance":1200,"distanceType":1,"raceTrackId":10001,"slopes":[],"straights":[{"end":400,"start":0},{"end":1200,"start":950}],"surface":1,"turn":1},"10102":{"corners":[{"length":275,"start":150},{"length":275,"start":700},{"length":275,"start":975}],"course":1,"courseSetStatus":[],"distance":1500,"distanceType":2,"raceTrackId":10001,"slopes":[],"straights":[{"end":700,"start":425},{"end":1500,"start":1250}],"surface":1,"turn":1},"10103":{"corners":[{"length":275,"start":175},{"length":275,"start":450},{"length":275,"start":1000},{"length":275,"start":1275}],"course":1,"courseSetStatus":[],"distance":1800,"distanceType":2,"raceTrackId":10001,"slopes":[],"straights":[{"end":175,"start":0},{"end":1000,"start":725},{"end":1800,"start":1550}],"surface":1,"turn":1},"10104":{"corners":[{"length":275,"start":375},{"length":275,"start":650},{"length":275,"start":1200},{"length":275,"start":1475}],"course":1,"courseSetStatus":[3],"distance":2000,"distanceType":3,"raceTrackId":10001,"slopes":[],"straights":[{"end":375,"start":0},{"end":1200,"start":925},{"end":2000,"start":1750}],"surface":1,"turn":1},"10105":{"corners":[{"length":275,"start":175},{"length":275,"start":450},{"length":275,"start":975},{"length":275,"start":1250},{"length":275,"start":1800},{"length":275,"start":2075}],"course":1,"courseSetStatus":[2],"distance":2600,"distanceType":4,"raceTrackId":10001,"slopes":[],"straights":[{"end":175,"start":0},{"end":975,"start":725},{"end":1800,"start":1525},{"end":2600,"start":2350}],"surface":1,"turn":1},"10106":{"corners":[{"length":230,"start":280},{"length":230,"start":510}],"course":1,"courseSetStatus":[],"distance":1000,"distanceType":1,"raceTrackId":10001,"slopes":[],"straights":[{"end":280,"start":0},{"end":1000,"start":740}],"surface":2,"turn":1},"10107":{"corners":[{"length":230,"start":240},{"length":230,"start":470},{"length":230,"start":980},{"length":230,"start":1210}],"course":1,"courseSetStatus":[1],"distance":1700,"distanceType":2,"raceTrackId":10001,"slopes":[],"straights":[{"end":240,"start":0},{"end":980,"start":700},{"end":1700,"start":1440}],"surface":2,"turn":1},"10108":{"corners":[{"length":230,"start":200},{"length":230,"start":430},{"length":230,"start":940},{"length":230,"start":1170},{"length":230,"start":1680},{"length":230,"start":1910}],"course":1,"courseSetStatus":[],"distance":2400,"distanceType":3,"raceTrackId":10001,"slopes":[],"straights":[{"end":200,"start":0},{"end":940,"start":660},{"end":1680,"start":1408},{"end":2400,"start":2140}],"surface":2,"turn":1},"10201":{"corners":[{"length":220,"start":310},{"length":220,"start":530}],"course":1,"courseSetStatus":[],"distance":1000,"distanceType":1,"raceTrackId":10002,"slopes":[{"length":555,"slope":10000,"start":0}],"straights":[{"end":310,"start":0},{"end":1000,"start":750}],"surface":1,"turn":1},"10202":{"corners":[{"length":220,"start":510},{"length":220,"start":730}],"course":1,"courseSetStatus":[],"distance":1200,"distanceType":1,"raceTrackId":10002,"slopes":[{"length":755,"slope":10000,"start":0}],"straights":[{"end":510,"start":0},{"end":1200,"start":950}],"surface":1,"turn":1},"10203":{"corners":[{"length":220,"start":320},{"length":220,"start":540},{"length":220,"start":1110},{"length":220,"start":1330}],"course":1,"courseSetStatus":[3],"distance":1800,"distanceType":2,"raceTrackId":10002,"slopes":[{"length":200,"slope":-10000,"start":220},{"length":720,"slope":10000,"start":665}],"straights":[{"end":320,"start":0},{"end":1110,"start":760},{"end":1800,"start":1550}],"surface":1,"turn":1},"10204":{"corners":[{"length":220,"start":520},{"length":220,"start":740},{"length":220,"start":1310},{"length":220,"start":1530}],"course":1,"courseSetStatus":[1],"distance":2000,"distanceType":3,"raceTrackId":10002,"slopes":[{"length":200,"slope":-10000,"start":420},{"length":720,"slope":10000,"start":865}],"straights":[{"end":520,"start":0},{"end":1310,"start":960},{"end":2000,"start":1750}],"surface":1,"turn":1},"10205":{"corners":[{"length":230,"start":240},{"length":230,"start":470},{"length":230,"start":1070},{"length":230,"start":1300},{"length":230,"start":1890},{"length":230,"start":2120}],"course":1,"courseSetStatus":[2],"distance":2600,"distanceType":4,"raceTrackId":10002,"slopes":[{"length":495,"slope":10000,"start":0},{"length":200,"slope":-10000,"start":970},{"length":720,"slope":10000,"start":1425}],"straights":[{"end":240,"start":0},{"end":1070,"start":700},{"end":1890,"start":1530},{"end":2600,"start":2350}],"surface":1,"turn":1},"10206":{"corners":[{"length":190,"start":370},{"length":190,"start":560}],"course":1,"courseSetStatus":[],"distance":1000,"distanceType":1,"raceTrackId":10002,"slopes":[],"straights":[{"end":370,"start":0},{"end":1000,"start":750}],"surface":2,"turn":1},"10207":{"corners":[{"length":190,"start":350},{"length":190,"start":540},{"length":190,"start":1070},{"length":190,"start":1260}],"course":1,"courseSetStatus":[],"distance":1700,"distanceType":2,"raceTrackId":10002,"slopes":[{"length":340,"slope":-10000,"start":275},{"length":670,"slope":10000,"start":615}],"straights":[{"end":350,"start":0},{"end":1070,"start":730},{"end":1700,"start":1450}],"surface":2,"turn":1},"10208":{"corners":[{"length":190,"start":292},{"length":190,"start":482},{"length":190,"start":1040},{"length":190,"start":1230},{"length":190,"start":1770},{"length":190,"start":1960}],"course":1,"courseSetStatus":[2],"distance":2400,"distanceType":3,"raceTrackId":10002,"slopes":[],"straights":[{"end":292,"start":0},{"end":1040,"start":672},{"end":1770,"start":1420},{"end":2400,"start":2150}],"surface":2,"turn":1},"10301":{"corners":[],"course":1,"courseSetStatus":[3],"distance":1000,"distanceType":1,"raceTrackId":10003,"slopes":[],"straights":[{"end":649.9,"start":0},{"end":1000,"start":650}],"surface":1,"turn":4},"10302":{"corners":[{"length":200,"start":430},{"length":210,"start":640}],"course":2,"courseSetStatus":[],"distance":1200,"distanceType":1,"raceTrackId":10003,"slopes":[],"straights":[{"end":430,"start":0},{"end":1200,"start":850}],"surface":1,"turn":2},"10303":{"corners":[{"length":200,"start":650},{"length":200,"start":850}],"course":2,"courseSetStatus":[],"distance":1400,"distanceType":1,"raceTrackId":10003,"slopes":[],"straights":[{"end":650,"start":0},{"end":1400,"start":1050}],"surface":1,"turn":2},"10304":{"corners":[{"length":200,"start":550},{"length":200,"start":750}],"course":3,"courseSetStatus":[],"distance":1600,"distanceType":2,"raceTrackId":10003,"slopes":[{"length":350,"slope":10000,"start":250},{"length":300,"slope":-15000,"start":600}],"straights":[{"end":550,"start":0},{"end":1600,"start":950}],"surface":1,"turn":2},"10305":{"corners":[{"length":200,"start":750},{"length":200,"start":950}],"course":3,"courseSetStatus":[3],"distance":1800,"distanceType":2,"raceTrackId":10003,"slopes":[{"length":350,"slope":10000,"start":450},{"length":300,"slope":-15000,"start":800}],"straights":[{"end":750,"start":0},{"end":1800,"start":1150}],"surface":1,"turn":2},"10306":{"corners":[{"length":200,"start":420},{"length":200,"start":620},{"length":200,"start":1250},{"length":200,"start":1450}],"course":2,"courseSetStatus":[2,3],"distance":2000,"distanceType":3,"raceTrackId":10003,"slopes":[],"straights":[{"end":420,"start":0},{"end":1250,"start":820},{"end":2000,"start":1650}],"surface":1,"turn":2},"10307":{"corners":[{"length":200,"start":950},{"length":200,"start":1150}],"course":3,"courseSetStatus":[2,3],"distance":2000,"distanceType":3,"raceTrackId":10003,"slopes":[{"length":300,"slope":-15000,"start":1000},{"length":350,"slope":10000,"start":650}],"straights":[{"end":950,"start":0},{"end":2000,"start":1350}],"surface":1,"turn":2},"10308":{"corners":[{"length":200,"start":650},{"length":200,"start":850},{"length":200,"start":1450},{"length":200,"start":1650}],"course":2,"courseSetStatus":[1],"distance":2200,"distanceType":3,"raceTrackId":10003,"slopes":[],"straights":[{"end":650,"start":0},{"end":1450,"start":1050},{"end":2200,"start":1850}],"surface":1,"turn":2},"10309":{"corners":[{"length":200,"start":810},{"length":200,"start":1010},{"length":200,"start":1650},{"length":200,"start":1850}],"course":2,"courseSetStatus":[],"distance":2400,"distanceType":3,"raceTrackId":10003,"slopes":[],"straights":[{"end":810,"start":0},{"end":1650,"start":1210},{"end":2400,"start":2050}],"surface":1,"turn":2},"10310":{"corners":[{"length":150,"start":600},{"length":150,"start":750}],"course":1,"courseSetStatus":[],"distance":1200,"distanceType":1,"raceTrackId":10003,"slopes":[],"straights":[{"end":600,"start":0},{"end":1200,"start":900}],"surface":2,"turn":2},"10311":{"corners":[{"length":160,"start":400},{"length":160,"start":560},{"length":160,"start":1140},{"length":160,"start":1300}],"course":1,"courseSetStatus":[5],"distance":1800,"distanceType":2,"raceTrackId":10003,"slopes":[],"straights":[{"end":400,"start":0},{"end":1140,"start":720},{"end":1800,"start":1460}],"surface":2,"turn":2},"10312":{"corners":[{"length":160,"start":380},{"length":160,"start":540},{"length":160,"start":1120},{"length":160,"start":1280},{"length":160,"start":1850},{"length":160,"start":2010}],"course":1,"courseSetStatus":[],"distance":2500,"distanceType":4,"raceTrackId":10003,"slopes":[],"straights":[{"end":380,"start":0},{"end":1120,"start":700},{"end":1850,"start":1440},{"end":2500,"start":2170}],"surface":2,"turn":2},"10401":{"corners":[{"length":300,"start":420},{"length":200,"start":720}],"course":1,"courseSetStatus":[],"distance":1200,"distanceType":1,"raceTrackId":10004,"slopes":[{"length":100,"slope":15000,"start":180}],"straights":[{"end":420,"start":0},{"end":1200,"start":920}],"surface":1,"turn":1},"10402":{"corners":[{"length":200,"start":330},{"length":200,"start":530},{"length":300,"start":1020},{"length":200,"start":1320}],"course":1,"courseSetStatus":[2],"distance":1800,"distanceType":2,"raceTrackId":10004,"slopes":[{"length":100,"slope":15000,"start":780}],"straights":[{"end":330,"start":0},{"end":1020,"start":730},{"end":1800,"start":1520}],"surface":1,"turn":1},"10403":{"corners":[{"length":200,"start":530},{"length":200,"start":730},{"length":300,"start":1220},{"length":200,"start":1520}],"course":1,"courseSetStatus":[2],"distance":2000,"distanceType":3,"raceTrackId":10004,"slopes":[{"length":100,"slope":15000,"start":980}],"straights":[{"end":530,"start":0},{"end":1220,"start":930},{"end":2000,"start":1720}],"surface":1,"turn":1},"10404":{"corners":[{"length":300,"start":220},{"length":200,"start":520},{"length":200,"start":1130},{"length":200,"start":1330},{"length":300,"start":1820},{"length":200,"start":2120}],"course":1,"courseSetStatus":[],"distance":2600,"distanceType":4,"raceTrackId":10004,"slopes":[{"length":80,"slope":15000,"start":0},{"length":100,"slope":15000,"start":1580}],"straights":[{"end":220,"start":0},{"end":1130,"start":720},{"end":1820,"start":1530},{"end":2600,"start":2320}],"surface":1,"turn":1},"10405":{"corners":[{"length":210,"start":500},{"length":160,"start":710}],"course":1,"courseSetStatus":[],"distance":1150,"distanceType":1,"raceTrackId":10004,"slopes":[],"straights":[{"end":500,"start":0},{"end":1150,"start":870}],"surface":2,"turn":1},"10406":{"corners":[{"length":170,"start":360},{"length":170,"start":530},{"length":210,"start":1050},{"length":160,"start":1260}],"course":1,"courseSetStatus":[3],"distance":1700,"distanceType":2,"raceTrackId":10004,"slopes":[{"length":320,"slope":-10000,"start":285}],"straights":[{"end":360,"start":0},{"end":1050,"start":700},{"end":1700,"start":1420}],"surface":2,"turn":1},"10407":{"corners":[{"length":210,"start":310},{"length":160,"start":520},{"length":170,"start":1060},{"length":170,"start":1230},{"length":210,"start":1750},{"length":160,"start":1960}],"course":1,"courseSetStatus":[2],"distance":2400,"distanceType":3,"raceTrackId":10004,"slopes":[],"straights":[{"end":310,"start":0},{"end":1060,"start":680},{"end":1750,"start":1400},{"end":2400,"start":2120}],"surface":2,"turn":1},"10501":{"corners":[{"length":350,"start":300},{"length":250,"start":650}],"course":3,"courseSetStatus":[],"distance":1200,"distanceType":1,"raceTrackId":10005,"slopes":[{"length":200,"slope":-15000,"start":0},{"length":110,"slope":20000,"start":1025}],"straights":[{"end":1200,"start":900}],"surface":1,"turn":1},"10502":{"corners":[{"length":450,"start":50},{"length":350,"start":700},{"length":250,"start":1050}],"course":3,"courseSetStatus":[3],"distance":1600,"distanceType":2,"raceTrackId":10005,"slopes":[{"length":300,"slope":-15000,"start":300},{"length":110,"slope":20000,"start":1425}],"straights":[{"end":1600,"start":1300}],"surface":1,"turn":1},"10503":{"corners":[{"length":250,"start":175},{"length":250,"start":425},{"length":250,"start":1000},{"length":250,"start":1250}],"course":2,"courseSetStatus":[],"distance":1800,"distanceType":2,"raceTrackId":10005,"slopes":[{"length":35,"slope":20000,"start":1},{"length":200,"slope":15000,"start":125},{"length":400,"slope":-15000,"start":425},{"length":110,"slope":20000,"start":1625}],"straights":[{"end":175,"start":0},{"end":1000,"start":675},{"end":1800,"start":1500}],"surface":1,"turn":1},"10504":{"corners":[{"length":250,"start":375},{"length":250,"start":625},{"length":250,"start":1200},{"length":250,"start":1450}],"course":2,"courseSetStatus":[1],"distance":2000,"distanceType":3,"raceTrackId":10005,"slopes":[{"length":200,"slope":15000,"start":325},{"length":110,"slope":20000,"start":125},{"length":400,"slope":-15000,"start":625},{"length":110,"slope":20000,"start":1825}],"straights":[{"end":375,"start":0},{"end":1200,"start":875},{"end":2000,"start":1700}],"surface":1,"turn":1},"10505":{"corners":[{"length":247,"start":403},{"length":450,"start":650},{"length":350,"start":1300},{"length":250,"start":1650}],"course":3,"courseSetStatus":[2,4],"distance":2200,"distanceType":3,"raceTrackId":10005,"slopes":[{"length":110,"slope":20000,"start":153},{"length":200,"slope":15000,"start":353},{"length":300,"slope":-15000,"start":900},{"length":110,"slope":20000,"start":2025}],"straights":[{"end":403,"start":0},{"end":2200,"start":1900}],"surface":1,"turn":1},"10506":{"corners":[{"length":146,"start":100},{"length":250,"start":246},{"length":250,"start":875},{"length":250,"start":1125},{"length":250,"start":1700},{"length":250,"start":1950}],"course":2,"courseSetStatus":[2,4],"distance":2500,"distanceType":4,"raceTrackId":10005,"slopes":[{"length":110,"slope":20000,"start":621},{"length":200,"slope":15000,"start":825},{"length":400,"slope":-15000,"start":1125},{"length":110,"slope":20000,"start":2325}],"straights":[{"end":875,"start":496},{"end":1700,"start":1375},{"end":2500,"start":2200}],"surface":1,"turn":1},"10507":{"corners":[{"length":250,"start":290},{"length":250,"start":540},{"length":250,"start":1115},{"length":250,"start":1365},{"length":250,"start":1975},{"length":250,"start":2225},{"length":250,"start":2800},{"length":250,"start":3050}],"course":2,"courseSetStatus":[2],"distance":3600,"distanceType":4,"raceTrackId":10005,"slopes":[{"length":110,"slope":20000,"start":40},{"length":200,"slope":15000,"start":240},{"length":400,"slope":-15000,"start":540},{"length":110,"slope":20000,"start":1740},{"length":200,"slope":15000,"start":1925},{"length":400,"slope":-15000,"start":2225},{"length":110,"slope":20000,"start":3425}],"straights":[{"end":290,"start":0},{"end":1115,"start":790},{"end":1975,"start":1615},{"end":2800,"start":2475},{"end":3600,"start":3300}],"surface":1,"turn":1},"10508":{"corners":[{"length":200,"start":500},{"length":200,"start":700}],"course":1,"courseSetStatus":[3],"distance":1200,"distanceType":1,"raceTrackId":10005,"slopes":[{"length":175,"slope":-15000,"start":175},{"length":175,"slope":15000,"start":1000}],"straights":[{"end":500,"start":0},{"end":1200,"start":900}],"surface":2,"turn":1},"10509":{"corners":[{"length":200,"start":350},{"length":200,"start":550},{"length":200,"start":1100},{"length":200,"start":1300}],"course":1,"courseSetStatus":[3],"distance":1800,"distanceType":2,"raceTrackId":10005,"slopes":[{"length":175,"slope":15000,"start":100},{"length":175,"slope":10000,"start":350},{"length":175,"slope":-15000,"start":775},{"length":175,"slope":15000,"start":1600}],"straights":[{"end":350,"start":0},{"end":1100,"start":750},{"end":1800,"start":1500}],"surface":2,"turn":1},"10510":{"corners":[{"length":200,"start":200},{"length":200,"start":400},{"length":200,"start":950},{"length":200,"start":1150},{"length":200,"start":1700},{"length":200,"start":1900}],"course":1,"courseSetStatus":[2],"distance":2400,"distanceType":3,"raceTrackId":10005,"slopes":[],"straights":[{"end":200,"start":0},{"end":950,"start":600},{"end":1700,"start":1350},{"end":2400,"start":2100}],"surface":2,"turn":1},"10511":{"corners":[{"length":200,"start":300},{"length":200,"start":500},{"length":200,"start":1050},{"length":200,"start":1250},{"length":200,"start":1800},{"length":200,"start":2000}],"course":1,"courseSetStatus":[],"distance":2500,"distanceType":4,"raceTrackId":10005,"slopes":[],"straights":[{"end":300,"start":0},{"end":1050,"start":700},{"end":1800,"start":1450},{"end":2500,"start":2200}],"surface":2,"turn":1},"10601":{"corners":[{"length":275,"start":350},{"length":275,"start":625}],"course":1,"courseSetStatus":[2,3],"distance":1400,"distanceType":1,"raceTrackId":10006,"slopes":[{"length":75,"slope":20000,"start":125},{"length":250,"slope":-15000,"start":250},{"length":150,"slope":15000,"start":950}],"straights":[{"end":350,"start":0},{"end":1400,"start":900}],"surface":1,"turn":2},"10602":{"corners":[{"length":275,"start":550},{"length":275,"start":825}],"course":1,"courseSetStatus":[2,4],"distance":1600,"distanceType":2,"raceTrackId":10006,"slopes":[{"length":250,"slope":-15000,"start":450},{"length":75,"slope":20000,"start":325},{"length":150,"slope":15000,"start":1150}],"straights":[{"end":550,"start":0},{"end":1600,"start":1100}],"surface":1,"turn":2},"10603":{"corners":[{"length":250,"start":75},{"length":275,"start":750},{"length":275,"start":1025}],"course":1,"courseSetStatus":[1],"distance":1800,"distanceType":2,"raceTrackId":10006,"slopes":[{"length":75,"slope":20000,"start":525},{"length":250,"slope":-15000,"start":650},{"length":150,"slope":15000,"start":1350}],"straights":[{"end":750,"start":325},{"end":1800,"start":1300}],"surface":1,"turn":2},"10604":{"corners":[{"length":200,"start":200},{"length":275,"start":950},{"length":275,"start":1225}],"course":1,"courseSetStatus":[],"distance":2000,"distanceType":3,"raceTrackId":10006,"slopes":[{"length":75,"slope":20000,"start":725},{"length":250,"slope":-15000,"start":850},{"length":150,"slope":15000,"start":1550}],"straights":[{"end":950,"start":400},{"end":2000,"start":1500}],"surface":1,"turn":2},"10605":{"corners":[{"length":250,"start":225},{"length":325,"start":475},{"length":275,"start":1250},{"length":275,"start":1525}],"course":1,"courseSetStatus":[3],"distance":2300,"distanceType":3,"raceTrackId":10006,"slopes":[{"length":75,"slope":20000,"start":1025},{"length":250,"slope":-15000,"start":1150},{"length":150,"slope":15000,"start":1850}],"straights":[{"end":225,"start":0},{"end":1250,"start":800},{"end":2300,"start":1800}],"surface":1,"turn":2},"10606":{"corners":[{"length":250,"start":325},{"length":325,"start":575},{"length":275,"start":1350},{"length":275,"start":1625}],"course":1,"courseSetStatus":[],"distance":2400,"distanceType":3,"raceTrackId":10006,"slopes":[{"length":75,"slope":20000,"start":1125},{"length":250,"slope":-15000,"start":1250},{"length":150,"slope":15000,"start":1950}],"straights":[{"end":325,"start":0},{"end":1350,"start":900},{"end":2400,"start":1900}],"surface":1,"turn":2},"10607":{"corners":[{"length":250,"start":425},{"length":325,"start":675},{"length":275,"start":1450},{"length":275,"start":1725}],"course":1,"courseSetStatus":[2],"distance":2500,"distanceType":4,"raceTrackId":10006,"slopes":[{"length":140,"slope":15000,"start":0},{"length":75,"slope":20000,"start":1225},{"length":250,"slope":-15000,"start":1350},{"length":150,"slope":15000,"start":2050}],"straights":[{"end":425,"start":0},{"end":1450,"start":1000},{"end":2500,"start":2000}],"surface":1,"turn":2},"10608":{"corners":[{"length":275,"start":292},{"length":275,"start":567},{"length":250,"start":1325},{"length":325,"start":1575},{"length":275,"start":2350},{"length":275,"start":2625}],"course":1,"courseSetStatus":[],"distance":3400,"distanceType":4,"raceTrackId":10006,"slopes":[{"length":75,"slope":20000,"start":67},{"length":250,"slope":-15000,"start":192},{"length":150,"slope":15000,"start":892},{"length":75,"slope":20000,"start":2125},{"length":250,"slope":-15000,"start":2250},{"length":150,"slope":15000,"start":2950}],"straights":[{"end":292,"start":0},{"end":1325,"start":842},{"end":2350,"start":1900},{"end":3400,"start":2900}],"surface":1,"turn":2},"10609":{"corners":[{"length":225,"start":350},{"length":225,"start":575}],"course":1,"courseSetStatus":[1],"distance":1300,"distanceType":1,"raceTrackId":10006,"slopes":[{"length":200,"slope":-10000,"start":275},{"length":250,"slope":15000,"start":800}],"straights":[{"end":350,"start":0},{"end":1300,"start":800}],"surface":2,"turn":2},"10610":{"corners":[{"length":225,"start":450},{"length":225,"start":675}],"course":1,"courseSetStatus":[2],"distance":1400,"distanceType":1,"raceTrackId":10006,"slopes":[{"length":200,"slope":-10000,"start":375},{"length":250,"slope":15000,"start":900}],"straights":[{"end":450,"start":0},{"end":1400,"start":900}],"surface":2,"turn":2},"10611":{"corners":[{"length":225,"start":650},{"length":225,"start":875}],"course":1,"courseSetStatus":[1,2],"distance":1600,"distanceType":2,"raceTrackId":10006,"slopes":[{"length":200,"slope":-10000,"start":575},{"length":250,"slope":15000,"start":1100}],"straights":[{"end":650,"start":0},{"end":1600,"start":1100}],"surface":2,"turn":2},"10612":{"corners":[{"length":250,"start":200},{"length":250,"start":450},{"length":225,"start":1150},{"length":225,"start":1375}],"course":1,"courseSetStatus":[],"distance":2100,"distanceType":3,"raceTrackId":10006,"slopes":[{"length":200,"slope":-10000,"start":1075},{"length":250,"slope":15000,"start":1600}],"straights":[{"end":200,"start":0},{"end":1150,"start":700},{"end":2100,"start":1600}],"surface":2,"turn":2},"10613":{"corners":[{"length":250,"start":500},{"length":250,"start":750},{"length":225,"start":1450},{"length":225,"start":1675},{"length":500,"start":2348}],"course":1,"courseSetStatus":[2],"distance":2400,"distanceType":3,"raceTrackId":10006,"slopes":[],"straights":[{"end":500,"start":0},{"end":1450,"start":1000},{"end":2400,"start":1900}],"surface":2,"turn":2},"10701":{"corners":[{"length":250,"start":300},{"length":250,"start":550}],"course":1,"courseSetStatus":[],"distance":1200,"distanceType":1,"raceTrackId":10007,"slopes":[{"length":775,"slope":-10000,"start":100},{"length":100,"slope":20000,"start":875}],"straights":[{"end":300,"start":0},{"end":1200,"start":800}],"surface":1,"turn":2},"10702":{"corners":[{"length":250,"start":500},{"length":250,"start":750}],"course":1,"courseSetStatus":[],"distance":1400,"distanceType":1,"raceTrackId":10007,"slopes":[{"length":775,"slope":-10000,"start":300},{"length":100,"slope":20000,"start":1075}],"straights":[{"end":500,"start":0},{"end":1400,"start":1000}],"surface":1,"turn":2},"10703":{"corners":[{"length":150,"start":150},{"length":250,"start":700},{"length":250,"start":950}],"course":1,"courseSetStatus":[1],"distance":1600,"distanceType":2,"raceTrackId":10007,"slopes":[{"length":775,"slope":-10000,"start":500},{"length":100,"slope":20000,"start":1275}],"straights":[{"end":700,"start":300},{"end":1600,"start":1200}],"surface":1,"turn":2},"10704":{"corners":[{"length":200,"start":300},{"length":200,"start":500},{"length":250,"start":1100},{"length":250,"start":1350}],"course":1,"courseSetStatus":[],"distance":2000,"distanceType":3,"raceTrackId":10007,"slopes":[{"length":50,"slope":20000,"start":0},{"length":775,"slope":-10000,"start":900},{"length":100,"slope":20000,"start":1675}],"straights":[{"end":300,"start":0},{"end":1100,"start":700},{"end":2000,"start":1600}],"surface":1,"turn":2},"10705":{"corners":[{"length":200,"start":500},{"length":200,"start":700},{"length":250,"start":1300},{"length":250,"start":1550}],"course":1,"courseSetStatus":[2],"distance":2200,"distanceType":3,"raceTrackId":10007,"slopes":[{"length":150,"slope":-10000,"start":0},{"length":100,"slope":20000,"start":150},{"length":775,"slope":-10000,"start":1100},{"length":100,"slope":20000,"start":1875}],"straights":[{"end":500,"start":0},{"end":1300,"start":900},{"end":2200,"start":1800}],"surface":1,"turn":2},"10706":{"corners":[{"length":200,"start":400},{"length":200,"start":600}],"course":1,"courseSetStatus":[],"distance":1200,"distanceType":1,"raceTrackId":10007,"slopes":[],"straights":[{"end":400,"start":0},{"end":1200,"start":800}],"surface":2,"turn":2},"10707":{"corners":[{"length":200,"start":600},{"length":200,"start":800}],"course":1,"courseSetStatus":[],"distance":1400,"distanceType":1,"raceTrackId":10007,"slopes":[{"length":600,"slope":-15000,"start":425},{"length":150,"slope":15000,"start":1025}],"straights":[{"end":600,"start":0},{"end":1400,"start":1000}],"surface":2,"turn":2},"10708":{"corners":[{"length":165,"start":270},{"length":165,"start":435},{"length":200,"start":1000},{"length":200,"start":1200}],"course":1,"courseSetStatus":[2],"distance":1800,"distanceType":2,"raceTrackId":10007,"slopes":[{"length":50,"slope":15000,"start":0},{"length":600,"slope":-15000,"start":825},{"length":150,"slope":15000,"start":1425}],"straights":[{"end":270,"start":0},{"end":1000,"start":600},{"end":1800,"start":1400}],"surface":2,"turn":2},"10709":{"corners":[{"length":165,"start":370},{"length":165,"start":535},{"length":200,"start":1100},{"length":200,"start":1300}],"course":1,"courseSetStatus":[],"distance":1900,"distanceType":3,"raceTrackId":10007,"slopes":[],"straights":[{"end":370,"start":0},{"end":1100,"start":700},{"end":1900,"start":1500}],"surface":2,"turn":2},"10801":{"corners":[{"length":275,"start":320},{"length":275,"start":595}],"course":2,"courseSetStatus":[],"distance":1200,"distanceType":1,"raceTrackId":10008,"slopes":[{"length":175,"slope":15000,"start":120},{"length":150,"slope":-15000,"start":420}],"straights":[{"end":320,"start":0},{"end":1200,"start":870}],"surface":1,"turn":1},"10802":{"corners":[{"length":275,"start":520},{"length":275,"start":795}],"course":2,"courseSetStatus":[],"distance":1400,"distanceType":1,"raceTrackId":10008,"slopes":[{"length":175,"slope":15000,"start":320},{"length":150,"slope":-15000,"start":620}],"straights":[{"end":520,"start":0},{"end":1400,"start":1070}],"surface":1,"turn":1},"10803":{"corners":[{"length":250,"start":500},{"length":250,"start":750}],"course":3,"courseSetStatus":[],"distance":1400,"distanceType":1,"raceTrackId":10008,"slopes":[{"length":100,"slope":20000,"start":250},{"length":225,"slope":10000,"start":350},{"length":150,"slope":-20000,"start":575}],"straights":[{"end":500,"start":0},{"end":1400,"start":1000}],"surface":1,"turn":1},"10804":{"corners":[{"length":275,"start":720},{"length":275,"start":995}],"course":2,"courseSetStatus":[1],"distance":1600,"distanceType":2,"raceTrackId":10008,"slopes":[{"length":175,"slope":15000,"start":520},{"length":150,"slope":-15000,"start":820}],"straights":[{"end":720,"start":200},{"end":1600,"start":1270}],"surface":1,"turn":1},"10805":{"corners":[{"length":250,"start":700},{"length":250,"start":950}],"course":3,"courseSetStatus":[1],"distance":1600,"distanceType":2,"raceTrackId":10008,"slopes":[{"length":100,"slope":20000,"start":450},{"length":225,"slope":10000,"start":550},{"length":150,"slope":-20000,"start":775}],"straights":[{"end":700,"start":200},{"end":1600,"start":1200}],"surface":1,"turn":1},"10806":{"corners":[{"length":250,"start":900},{"length":250,"start":1150}],"course":3,"courseSetStatus":[],"distance":1800,"distanceType":2,"raceTrackId":10008,"slopes":[{"length":100,"slope":20000,"start":650},{"length":225,"slope":10000,"start":750},{"length":150,"slope":-20000,"start":975}],"straights":[{"end":900,"start":400},{"end":1800,"start":1400}],"surface":1,"turn":1},"10807":{"corners":[{"length":185,"start":400},{"length":185,"start":585},{"length":250,"start":1170},{"length":250,"start":1420}],"course":2,"courseSetStatus":[3],"distance":2000,"distanceType":3,"raceTrackId":10008,"slopes":[{"length":175,"slope":15000,"start":970},{"length":150,"slope":-15000,"start":1270}],"straights":[{"end":400,"start":0},{"end":1170,"start":770},{"end":2000,"start":1670}],"surface":1,"turn":1},"10808":{"corners":[{"length":200,"start":400},{"length":200,"start":600},{"length":250,"start":1300},{"length":250,"start":1550}],"course":3,"courseSetStatus":[1],"distance":2200,"distanceType":3,"raceTrackId":10008,"slopes":[{"length":100,"slope":20000,"start":1050},{"length":225,"slope":10000,"start":1150},{"length":150,"slope":-20000,"start":1375}],"straights":[{"end":400,"start":0},{"end":1300,"start":800},{"end":2200,"start":1800}],"surface":1,"turn":1},"10809":{"corners":[{"length":200,"start":600},{"length":200,"start":800},{"length":250,"start":1500},{"length":250,"start":1750}],"course":3,"courseSetStatus":[3],"distance":2400,"distanceType":3,"raceTrackId":10008,"slopes":[{"length":225,"slope":10000,"start":1350},{"length":100,"slope":20000,"start":1250},{"length":150,"slope":-20000,"start":1575}],"straights":[{"end":600,"start":0},{"end":1500,"start":1000},{"end":2400,"start":2000}],"surface":1,"turn":1},"10810":{"corners":[{"length":250,"start":261},{"length":250,"start":511},{"length":200,"start":1250},{"length":200,"start":1450},{"length":250,"start":2100},{"length":250,"start":2350}],"course":3,"courseSetStatus":[3,5],"distance":3000,"distanceType":4,"raceTrackId":10008,"slopes":[{"length":100,"slope":20000,"start":11},{"length":225,"slope":10000,"start":111},{"length":150,"slope":-20000,"start":336},{"length":225,"slope":10000,"start":1950},{"length":100,"slope":20000,"start":1850},{"length":150,"slope":-20000,"start":2175}],"straights":[{"end":261,"start":0},{"end":1250,"start":761},{"end":2100,"start":1650},{"end":3000,"start":2600}],"surface":1,"turn":1},"10811":{"corners":[{"length":250,"start":458},{"length":250,"start":708},{"length":200,"start":1450},{"length":200,"start":1650},{"length":250,"start":2300},{"length":250,"start":2550}],"course":3,"courseSetStatus":[],"distance":3200,"distanceType":4,"raceTrackId":10008,"slopes":[{"length":100,"slope":20000,"start":208},{"length":225,"slope":10000,"start":308},{"length":150,"slope":-20000,"start":533},{"length":100,"slope":20000,"start":2050},{"length":150,"slope":-20000,"start":2375},{"length":225,"slope":10000,"start":2150}],"straights":[{"end":458,"start":0},{"end":1450,"start":958},{"end":2300,"start":1850},{"end":3200,"start":2800}],"surface":1,"turn":1},"10812":{"corners":[{"length":225,"start":400},{"length":225,"start":625}],"course":1,"courseSetStatus":[],"distance":1200,"distanceType":1,"raceTrackId":10008,"slopes":[{"length":200,"slope":15000,"start":175},{"length":200,"slope":-15000,"start":475}],"straights":[{"end":400,"start":0},{"end":1200,"start":850}],"surface":2,"turn":1},"10813":{"corners":[{"length":225,"start":600},{"length":225,"start":825}],"course":1,"courseSetStatus":[],"distance":1400,"distanceType":1,"raceTrackId":10008,"slopes":[{"length":200,"slope":15000,"start":375},{"length":200,"slope":-15000,"start":675}],"straights":[{"end":600,"start":100},{"end":1400,"start":1050}],"surface":2,"turn":1},"10814":{"corners":[{"length":150,"start":300},{"length":150,"start":450},{"length":225,"start":1000},{"length":225,"start":1225}],"course":1,"courseSetStatus":[],"distance":1800,"distanceType":2,"raceTrackId":10008,"slopes":[{"length":200,"slope":15000,"start":775},{"length":200,"slope":-15000,"start":1075}],"straights":[{"end":300,"start":0},{"end":1000,"start":600},{"end":1800,"start":1450}],"surface":2,"turn":1},"10815":{"corners":[{"length":150,"start":400},{"length":150,"start":550},{"length":225,"start":1100},{"length":225,"start":1325}],"course":1,"courseSetStatus":[],"distance":1900,"distanceType":3,"raceTrackId":10008,"slopes":[{"length":200,"slope":15000,"start":875},{"length":200,"slope":-15000,"start":1175}],"straights":[{"end":400,"start":0},{"end":1100,"start":700},{"end":1900,"start":1550}],"surface":2,"turn":1},"10901":{"corners":[{"length":300,"start":250},{"length":300,"start":550}],"course":2,"courseSetStatus":[],"distance":1200,"distanceType":1,"raceTrackId":10009,"slopes":[{"length":595,"slope":-10000,"start":400},{"length":125,"slope":20000,"start":1000}],"straights":[{"end":250,"start":0},{"end":1200,"start":850}],"surface":1,"turn":1},"10902":{"corners":[{"length":300,"start":450},{"length":300,"start":750}],"course":2,"courseSetStatus":[],"distance":1400,"distanceType":1,"raceTrackId":10009,"slopes":[{"length":595,"slope":-10000,"start":600},{"length":125,"slope":20000,"start":1200}],"straights":[{"end":450,"start":0},{"end":1400,"start":1050}],"surface":1,"turn":1},"10903":{"corners":[{"length":350,"start":450},{"length":350,"start":800}],"course":3,"courseSetStatus":[3],"distance":1600,"distanceType":2,"raceTrackId":10009,"slopes":[{"length":400,"slope":-10000,"start":950},{"length":120,"slope":20000,"start":1405}],"straights":[{"end":450,"start":0},{"end":1600,"start":1150}],"surface":1,"turn":1},"10904":{"corners":[{"length":350,"start":650},{"length":350,"start":1000}],"course":3,"courseSetStatus":[3],"distance":1800,"distanceType":2,"raceTrackId":10009,"slopes":[{"length":400,"slope":-10000,"start":1150},{"length":120,"slope":20000,"start":1605}],"straights":[{"end":650,"start":0},{"end":1800,"start":1350}],"surface":1,"turn":1},"10905":{"corners":[{"length":190,"start":370},{"length":190,"start":560},{"length":300,"start":1050},{"length":300,"start":1350}],"course":2,"courseSetStatus":[4],"distance":2000,"distanceType":3,"raceTrackId":10009,"slopes":[{"length":140,"slope":-10000,"start":0},{"length":125,"slope":20000,"start":145},{"length":595,"slope":-10000,"start":1200},{"length":125,"slope":20000,"start":1800}],"straights":[{"end":370,"start":0},{"end":1050,"start":750},{"end":2000,"start":1650}],"surface":1,"turn":1},"10906":{"corners":[{"length":190,"start":520},{"length":190,"start":710},{"length":300,"start":1250},{"length":300,"start":1550}],"course":2,"courseSetStatus":[1],"distance":2200,"distanceType":3,"raceTrackId":10009,"slopes":[{"length":290,"slope":-10000,"start":0},{"length":125,"slope":20000,"start":295},{"length":595,"slope":-10000,"start":1400},{"length":125,"slope":20000,"start":2000}],"straights":[{"end":520,"start":0},{"end":1250,"start":900},{"end":2200,"start":1850}],"surface":1,"turn":1},"10907":{"corners":[{"length":190,"start":382},{"length":190,"start":558},{"length":350,"start":1250},{"length":350,"start":1600}],"course":3,"courseSetStatus":[3],"distance":2400,"distanceType":3,"raceTrackId":10009,"slopes":[{"length":132,"slope":-10000,"start":0},{"length":120,"slope":20000,"start":187},{"length":400,"slope":-10000,"start":1750},{"length":120,"slope":20000,"start":2205}],"straights":[{"end":1250,"start":750},{"end":2400,"start":1950}],"surface":1,"turn":1},"10908":{"corners":[{"length":190,"start":570},{"length":190,"start":760},{"length":350,"start":1450},{"length":350,"start":1800}],"course":3,"courseSetStatus":[],"distance":2600,"distanceType":4,"raceTrackId":10009,"slopes":[{"length":315,"slope":-10000,"start":0},{"length":120,"slope":20000,"start":370},{"length":400,"slope":-10000,"start":1950},{"length":120,"slope":20000,"start":2405}],"straights":[{"end":570,"start":0},{"end":1450,"start":950},{"end":2600,"start":2150}],"surface":1,"turn":1},"10909":{"corners":[{"length":300,"start":348},{"length":300,"start":648},{"length":190,"start":1320},{"length":190,"start":1510},{"length":300,"start":2050},{"length":300,"start":2350}],"course":2,"courseSetStatus":[3],"distance":3000,"distanceType":4,"raceTrackId":10009,"slopes":[{"length":595,"slope":-10000,"start":498},{"length":125,"slope":20000,"start":1095},{"length":595,"slope":-10000,"start":2200},{"length":125,"slope":20000,"start":2800}],"straights":[{"end":348,"start":0},{"end":1320,"start":948},{"end":2050,"start":1700},{"end":3000,"start":2650}],"surface":1,"turn":1},"10910":{"corners":[{"length":250,"start":350},{"length":250,"start":600}],"course":1,"courseSetStatus":[],"distance":1200,"distanceType":1,"raceTrackId":10009,"slopes":[],"straights":[{"end":350,"start":0},{"end":1200,"start":850}],"surface":2,"turn":1},"10911":{"corners":[{"length":250,"start":550},{"length":250,"start":800}],"course":1,"courseSetStatus":[],"distance":1400,"distanceType":1,"raceTrackId":10009,"slopes":[{"length":125,"slope":15000,"start":1200}],"straights":[{"end":550,"start":0},{"end":1400,"start":1050}],"surface":2,"turn":1},"10912":{"corners":[{"length":150,"start":330},{"length":150,"start":480},{"length":250,"start":950},{"length":250,"start":1200}],"course":1,"courseSetStatus":[],"distance":1800,"distanceType":2,"raceTrackId":10009,"slopes":[{"length":125,"slope":15000,"start":105},{"length":125,"slope":15000,"start":1599}],"straights":[{"end":330,"start":0},{"end":950,"start":630},{"end":1800,"start":1449}],"surface":2,"turn":1},"10913":{"corners":[{"length":150,"start":500},{"length":150,"start":650},{"length":250,"start":1150},{"length":250,"start":1400}],"course":1,"courseSetStatus":[2,3],"distance":2000,"distanceType":3,"raceTrackId":10009,"slopes":[{"length":125,"slope":15000,"start":275},{"length":125,"slope":15000,"start":1800}],"straights":[{"end":500,"start":0},{"end":1150,"start":800},{"end":2000,"start":1650}],"surface":2,"turn":1},"10914":{"corners":[{"length":350,"start":370},{"length":350,"start":720},{"length":190,"start":1520},{"length":190,"start":1710},{"length":300,"start":2250},{"length":300,"start":2550}],"course":4,"courseSetStatus":[],"distance":3200,"distanceType":4,"raceTrackId":10009,"slopes":[{"length":400,"slope":-10000,"start":870},{"length":120,"slope":20000,"start":1325},{"length":595,"slope":-10000,"start":2400},{"length":125,"slope":20000,"start":3000}],"straights":[{"end":370,"start":0},{"end":1520,"start":1070},{"end":2250,"start":1900},{"end":3200,"start":2850}],"surface":1,"turn":1},"11001":{"corners":[{"length":205,"start":500},{"length":205,"start":705}],"course":1,"courseSetStatus":[1],"distance":1200,"distanceType":1,"raceTrackId":10010,"slopes":[{"length":60,"slope":-15000,"start":0}],"straights":[{"end":500,"start":0},{"end":1200,"start":910}],"surface":1,"turn":1},"11002":{"corners":[{"length":205,"start":290},{"length":205,"start":495},{"length":205,"start":1100},{"length":205,"start":1305}],"course":1,"courseSetStatus":[],"distance":1800,"distanceType":2,"raceTrackId":10010,"slopes":[{"length":255,"slope":15000,"start":280}],"straights":[{"end":290,"start":0},{"end":1100,"start":700},{"end":1800,"start":1510}],"surface":1,"turn":1},"11003":{"corners":[{"length":205,"start":490},{"length":205,"start":695},{"length":205,"start":1300},{"length":205,"start":1505}],"course":1,"courseSetStatus":[3],"distance":2000,"distanceType":3,"raceTrackId":10010,"slopes":[{"length":255,"slope":15000,"start":480}],"straights":[{"end":490,"start":0},{"end":1300,"start":900},{"end":2000,"start":1710}],"surface":1,"turn":1},"11004":{"corners":[{"length":205,"start":309},{"length":205,"start":514},{"length":205,"start":1110},{"length":205,"start":1315},{"length":205,"start":1900},{"length":205,"start":2105}],"course":1,"courseSetStatus":[2],"distance":2600,"distanceType":4,"raceTrackId":10010,"slopes":[{"length":255,"slope":15000,"start":1100}],"straights":[{"end":309,"start":0},{"end":1110,"start":719},{"end":1900,"start":1520},{"end":2600,"start":2310}],"surface":1,"turn":1},"11005":{"corners":[{"length":180,"start":360},{"length":180,"start":540}],"course":1,"courseSetStatus":[1],"distance":1000,"distanceType":1,"raceTrackId":10010,"slopes":[],"straights":[{"end":360,"start":0},{"end":1000,"start":720}],"surface":2,"turn":1},"11006":{"corners":[{"length":180,"start":340},{"length":180,"start":520},{"length":180,"start":1060},{"length":180,"start":1240}],"course":1,"courseSetStatus":[],"distance":1700,"distanceType":2,"raceTrackId":10010,"slopes":[{"length":150,"slope":15000,"start":370}],"straights":[{"end":340,"start":0},{"end":1060,"start":700},{"end":1700,"start":1420}],"surface":2,"turn":1},"11007":{"corners":[{"length":180,"start":312},{"length":180,"start":492},{"length":180,"start":1040},{"length":180,"start":1220},{"length":180,"start":1760},{"length":180,"start":1940}],"course":1,"courseSetStatus":[],"distance":2400,"distanceType":3,"raceTrackId":10010,"slopes":[],"straights":[{"end":312,"start":0},{"end":1040,"start":672},{"end":1760,"start":1400},{"end":2400,"start":2120}],"surface":2,"turn":1},"11101":{"corners":[{"length":150,"start":500},{"length":150,"start":650}],"course":1,"courseSetStatus":[],"distance":1200,"distanceType":1,"raceTrackId":10101,"slopes":[],"straights":[{"end":500,"start":0},{"end":1200,"start":812}],"surface":2,"turn":1},"11102":{"corners":[{"length":150,"start":300},{"length":150,"start":500},{"length":150,"start":1100},{"length":150,"start":1250}],"course":1,"courseSetStatus":[],"distance":1800,"distanceType":2,"raceTrackId":10101,"slopes":[],"straights":[{"end":301,"start":0},{"end":1100.23,"start":600},{"end":1800,"start":1400}],"surface":2,"turn":1},"11103":{"corners":[{"length":150,"start":500},{"length":150,"start":650},{"length":150,"start":1300},{"length":150,"start":1450}],"course":1,"courseSetStatus":[],"distance":2000,"distanceType":3,"raceTrackId":10101,"slopes":[],"straights":[{"end":500,"start":0},{"end":1300,"start":800},{"end":2000,"start":1600}],"surface":2,"turn":1}}
+{
+    "10101": {
+        "corners": [
+            {
+                "length": 275,
+                "start": 400
+            },
+            {
+                "length": 275,
+                "start": 675
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1200,
+        "distanceType": 1,
+        "raceTrackId": 10001,
+        "slopes": [
+            {
+                "start": 106,
+                "length": 132,
+                "slope": -13658.779454831994
+            },
+            {
+                "start": 297,
+                "length": 84,
+                "slope": 13697.022475759184
+            },
+            {
+                "start": 444,
+                "length": 105,
+                "slope": -13343.314315891834
+            }
+        ],
+        "straights": [
+            {
+                "end": 400,
+                "start": 0
+            },
+            {
+                "end": 1200,
+                "start": 950
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10102": {
+        "corners": [
+            {
+                "length": 275,
+                "start": 150
+            },
+            {
+                "length": 275,
+                "start": 700
+            },
+            {
+                "length": 275,
+                "start": 975
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1500,
+        "distanceType": 2,
+        "raceTrackId": 10001,
+        "slopes": [
+            {
+                "start": 621,
+                "length": 27,
+                "slope": 10224.118405066165
+            },
+            {
+                "start": 726,
+                "length": 126,
+                "slope": -14747.959281922656
+            }
+        ],
+        "straights": [
+            {
+                "end": 700,
+                "start": 425
+            },
+            {
+                "end": 1500,
+                "start": 1250
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10103": {
+        "corners": [
+            {
+                "length": 275,
+                "start": 175
+            },
+            {
+                "length": 275,
+                "start": 450
+            },
+            {
+                "length": 275,
+                "start": 1000
+            },
+            {
+                "length": 275,
+                "start": 1275
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1800,
+        "distanceType": 2,
+        "raceTrackId": 10001,
+        "slopes": [
+            {
+                "start": 866,
+                "length": 102,
+                "slope": 16575.984653375035
+            },
+            {
+                "start": 1022,
+                "length": 125,
+                "slope": -14390.600844852579
+            }
+        ],
+        "straights": [
+            {
+                "end": 175,
+                "start": 0
+            },
+            {
+                "end": 1000,
+                "start": 725
+            },
+            {
+                "end": 1800,
+                "start": 1550
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10104": {
+        "corners": [
+            {
+                "length": 275,
+                "start": 375
+            },
+            {
+                "length": 275,
+                "start": 650
+            },
+            {
+                "length": 275,
+                "start": 1200
+            },
+            {
+                "length": 275,
+                "start": 1475
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            3
+        ],
+        "distance": 2000,
+        "distanceType": 3,
+        "raceTrackId": 10001,
+        "slopes": [
+            {
+                "start": 1075,
+                "length": 91,
+                "slope": 14837.395277821317
+            },
+            {
+                "start": 1227,
+                "length": 108,
+                "slope": -13319.853613322479
+            }
+        ],
+        "straights": [
+            {
+                "end": 375,
+                "start": 0
+            },
+            {
+                "end": 1200,
+                "start": 925
+            },
+            {
+                "end": 2000,
+                "start": 1750
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10105": {
+        "corners": [
+            {
+                "length": 275,
+                "start": 175
+            },
+            {
+                "length": 275,
+                "start": 450
+            },
+            {
+                "length": 275,
+                "start": 975
+            },
+            {
+                "length": 275,
+                "start": 1250
+            },
+            {
+                "length": 275,
+                "start": 1800
+            },
+            {
+                "length": 275,
+                "start": 2075
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            2
+        ],
+        "distance": 2600,
+        "distanceType": 4,
+        "raceTrackId": 10001,
+        "slopes": [
+            {
+                "start": 34,
+                "length": 37,
+                "slope": 12718.643363708981
+            },
+            {
+                "start": 92,
+                "length": 73,
+                "slope": 29058.64030040597
+            },
+            {
+                "start": 219,
+                "length": 55,
+                "slope": -10712.038794833159
+            },
+            {
+                "start": 850,
+                "length": 238,
+                "slope": -15575.624733528048
+            },
+            {
+                "start": 1675,
+                "length": 92,
+                "slope": 14780.173684557452
+            },
+            {
+                "start": 1827,
+                "length": 108,
+                "slope": -13318.094610903598
+            }
+        ],
+        "straights": [
+            {
+                "end": 175,
+                "start": 0
+            },
+            {
+                "end": 975,
+                "start": 725
+            },
+            {
+                "end": 1800,
+                "start": 1525
+            },
+            {
+                "end": 2600,
+                "start": 2350
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10106": {
+        "corners": [
+            {
+                "length": 230,
+                "start": 280
+            },
+            {
+                "length": 230,
+                "start": 510
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1000,
+        "distanceType": 1,
+        "raceTrackId": 10001,
+        "slopes": [
+            {
+                "start": 284,
+                "length": 95,
+                "slope": -21478.67570922132
+            }
+        ],
+        "straights": [
+            {
+                "end": 280,
+                "start": 0
+            },
+            {
+                "end": 1000,
+                "start": 740
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10107": {
+        "corners": [
+            {
+                "length": 230,
+                "start": 240
+            },
+            {
+                "length": 230,
+                "start": 470
+            },
+            {
+                "length": 230,
+                "start": 980
+            },
+            {
+                "length": 230,
+                "start": 1210
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            1
+        ],
+        "distance": 1700,
+        "distanceType": 2,
+        "raceTrackId": 10001,
+        "slopes": [
+            {
+                "start": 990,
+                "length": 76,
+                "slope": -14737.568337609882
+            }
+        ],
+        "straights": [
+            {
+                "end": 240,
+                "start": 0
+            },
+            {
+                "end": 980,
+                "start": 700
+            },
+            {
+                "end": 1700,
+                "start": 1440
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10108": {
+        "corners": [
+            {
+                "length": 230,
+                "start": 200
+            },
+            {
+                "length": 230,
+                "start": 430
+            },
+            {
+                "length": 230,
+                "start": 940
+            },
+            {
+                "length": 230,
+                "start": 1170
+            },
+            {
+                "length": 230,
+                "start": 1680
+            },
+            {
+                "length": 230,
+                "start": 1910
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 2400,
+        "distanceType": 3,
+        "raceTrackId": 10001,
+        "slopes": [
+            {
+                "start": 88,
+                "length": 65,
+                "slope": 11252.179456823753
+            },
+            {
+                "start": 213,
+                "length": 76,
+                "slope": -15695.36457816174
+            },
+            {
+                "start": 1689,
+                "length": 77,
+                "slope": -15620.212171927884
+            }
+        ],
+        "straights": [
+            {
+                "end": 200,
+                "start": 0
+            },
+            {
+                "end": 940,
+                "start": 660
+            },
+            {
+                "end": 1680,
+                "start": 1408
+            },
+            {
+                "end": 2400,
+                "start": 2140
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10201": {
+        "corners": [
+            {
+                "length": 220,
+                "start": 310
+            },
+            {
+                "length": 220,
+                "start": 530
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1000,
+        "distanceType": 1,
+        "raceTrackId": 10002,
+        "slopes": [],
+        "straights": [
+            {
+                "end": 310,
+                "start": 0
+            },
+            {
+                "end": 1000,
+                "start": 750
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10202": {
+        "corners": [
+            {
+                "length": 220,
+                "start": 510
+            },
+            {
+                "length": 220,
+                "start": 730
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1200,
+        "distanceType": 1,
+        "raceTrackId": 10002,
+        "slopes": [
+            {
+                "start": 88,
+                "length": 5,
+                "slope": 10377.779997982689
+            }
+        ],
+        "straights": [
+            {
+                "end": 510,
+                "start": 0
+            },
+            {
+                "end": 1200,
+                "start": 950
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10203": {
+        "corners": [
+            {
+                "length": 220,
+                "start": 320
+            },
+            {
+                "length": 220,
+                "start": 540
+            },
+            {
+                "length": 220,
+                "start": 1110
+            },
+            {
+                "length": 220,
+                "start": 1330
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            3
+        ],
+        "distance": 1800,
+        "distanceType": 2,
+        "raceTrackId": 10002,
+        "slopes": [
+            {
+                "start": 269,
+                "length": 7,
+                "slope": -13677.714437123861
+            },
+            {
+                "start": 289,
+                "length": 24,
+                "slope": -13952.742703510228
+            },
+            {
+                "start": 327,
+                "length": 89,
+                "slope": -15080.236875794983
+            }
+        ],
+        "straights": [
+            {
+                "end": 320,
+                "start": 0
+            },
+            {
+                "end": 1110,
+                "start": 760
+            },
+            {
+                "end": 1800,
+                "start": 1550
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10204": {
+        "corners": [
+            {
+                "length": 220,
+                "start": 520
+            },
+            {
+                "length": 220,
+                "start": 740
+            },
+            {
+                "length": 220,
+                "start": 1310
+            },
+            {
+                "length": 220,
+                "start": 1530
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            1
+        ],
+        "distance": 2000,
+        "distanceType": 3,
+        "raceTrackId": 10002,
+        "slopes": [
+            {
+                "start": 450,
+                "length": 55,
+                "slope": -15691.458160530909
+            }
+        ],
+        "straights": [
+            {
+                "end": 520,
+                "start": 0
+            },
+            {
+                "end": 1310,
+                "start": 960
+            },
+            {
+                "end": 2000,
+                "start": 1750
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10205": {
+        "corners": [
+            {
+                "length": 230,
+                "start": 240
+            },
+            {
+                "length": 230,
+                "start": 470
+            },
+            {
+                "length": 230,
+                "start": 1070
+            },
+            {
+                "length": 230,
+                "start": 1300
+            },
+            {
+                "length": 230,
+                "start": 1890
+            },
+            {
+                "length": 230,
+                "start": 2120
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            2
+        ],
+        "distance": 2600,
+        "distanceType": 4,
+        "raceTrackId": 10002,
+        "slopes": [
+            {
+                "start": 1023,
+                "length": 42,
+                "slope": -15505.457447491166
+            }
+        ],
+        "straights": [
+            {
+                "end": 240,
+                "start": 0
+            },
+            {
+                "end": 1070,
+                "start": 700
+            },
+            {
+                "end": 1890,
+                "start": 1530
+            },
+            {
+                "end": 2600,
+                "start": 2350
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10206": {
+        "corners": [
+            {
+                "length": 190,
+                "start": 370
+            },
+            {
+                "length": 190,
+                "start": 560
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1000,
+        "distanceType": 1,
+        "raceTrackId": 10002,
+        "slopes": [
+            {
+                "start": 175,
+                "length": 56,
+                "slope": 11946.848354586788
+            }
+        ],
+        "straights": [
+            {
+                "end": 370,
+                "start": 0
+            },
+            {
+                "end": 1000,
+                "start": 750
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10207": {
+        "corners": [
+            {
+                "length": 190,
+                "start": 350
+            },
+            {
+                "length": 190,
+                "start": 540
+            },
+            {
+                "length": 190,
+                "start": 1070
+            },
+            {
+                "length": 190,
+                "start": 1260
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1700,
+        "distanceType": 2,
+        "raceTrackId": 10002,
+        "slopes": [
+            {
+                "start": 300,
+                "length": 35,
+                "slope": -14669.526010262345
+            },
+            {
+                "start": 353,
+                "length": 7,
+                "slope": -17155.535634318738
+            }
+        ],
+        "straights": [
+            {
+                "end": 350,
+                "start": 0
+            },
+            {
+                "end": 1070,
+                "start": 730
+            },
+            {
+                "end": 1700,
+                "start": 1450
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10208": {
+        "corners": [
+            {
+                "length": 190,
+                "start": 292
+            },
+            {
+                "length": 190,
+                "start": 482
+            },
+            {
+                "length": 190,
+                "start": 1040
+            },
+            {
+                "length": 190,
+                "start": 1230
+            },
+            {
+                "length": 190,
+                "start": 1770
+            },
+            {
+                "length": 190,
+                "start": 1960
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            2
+        ],
+        "distance": 2400,
+        "distanceType": 3,
+        "raceTrackId": 10002,
+        "slopes": [
+            {
+                "start": 682,
+                "length": 78,
+                "slope": -10820.432678147059
+            },
+            {
+                "start": 972,
+                "length": 5,
+                "slope": -10661.391551836306
+            },
+            {
+                "start": 1132,
+                "length": 17,
+                "slope": -10217.715231647
+            },
+            {
+                "start": 2157,
+                "length": 79,
+                "slope": -10809.526250175513
+            }
+        ],
+        "straights": [
+            {
+                "end": 292,
+                "start": 0
+            },
+            {
+                "end": 1040,
+                "start": 672
+            },
+            {
+                "end": 1770,
+                "start": 1420
+            },
+            {
+                "end": 2400,
+                "start": 2150
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10301": {
+        "corners": [],
+        "course": 1,
+        "courseSetStatus": [
+            3
+        ],
+        "distance": 1000,
+        "distanceType": 1,
+        "raceTrackId": 10003,
+        "slopes": [],
+        "straights": [
+            {
+                "end": 649.9,
+                "start": 0
+            },
+            {
+                "end": 1000,
+                "start": 650
+            }
+        ],
+        "surface": 1,
+        "turn": 4
+    },
+    "10302": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 430
+            },
+            {
+                "length": 210,
+                "start": 640
+            }
+        ],
+        "course": 2,
+        "courseSetStatus": [],
+        "distance": 1200,
+        "distanceType": 1,
+        "raceTrackId": 10003,
+        "slopes": [],
+        "straights": [
+            {
+                "end": 430,
+                "start": 0
+            },
+            {
+                "end": 1200,
+                "start": 850
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10303": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 650
+            },
+            {
+                "length": 200,
+                "start": 850
+            }
+        ],
+        "course": 2,
+        "courseSetStatus": [],
+        "distance": 1400,
+        "distanceType": 1,
+        "raceTrackId": 10003,
+        "slopes": [],
+        "straights": [
+            {
+                "end": 650,
+                "start": 0
+            },
+            {
+                "end": 1400,
+                "start": 1050
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10304": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 550
+            },
+            {
+                "length": 200,
+                "start": 750
+            }
+        ],
+        "course": 3,
+        "courseSetStatus": [],
+        "distance": 1600,
+        "distanceType": 2,
+        "raceTrackId": 10003,
+        "slopes": [
+            {
+                "start": 552,
+                "length": 16,
+                "slope": 10506.281405337562
+            }
+        ],
+        "straights": [
+            {
+                "end": 550,
+                "start": 0
+            },
+            {
+                "end": 1600,
+                "start": 950
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10305": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 750
+            },
+            {
+                "length": 200,
+                "start": 950
+            }
+        ],
+        "course": 3,
+        "courseSetStatus": [
+            3
+        ],
+        "distance": 1800,
+        "distanceType": 2,
+        "raceTrackId": 10003,
+        "slopes": [
+            {
+                "start": 977,
+                "length": 17,
+                "slope": 10412.324731852608
+            },
+            {
+                "start": 1308,
+                "length": 57,
+                "slope": -11611.562430774371
+            }
+        ],
+        "straights": [
+            {
+                "end": 750,
+                "start": 0
+            },
+            {
+                "end": 1800,
+                "start": 1150
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10306": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 420
+            },
+            {
+                "length": 200,
+                "start": 620
+            },
+            {
+                "length": 200,
+                "start": 1250
+            },
+            {
+                "length": 200,
+                "start": 1450
+            }
+        ],
+        "course": 2,
+        "courseSetStatus": [
+            2,
+            3
+        ],
+        "distance": 2000,
+        "distanceType": 3,
+        "raceTrackId": 10003,
+        "slopes": [],
+        "straights": [
+            {
+                "end": 420,
+                "start": 0
+            },
+            {
+                "end": 1250,
+                "start": 820
+            },
+            {
+                "end": 2000,
+                "start": 1650
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10307": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 950
+            },
+            {
+                "length": 200,
+                "start": 1150
+            }
+        ],
+        "course": 3,
+        "courseSetStatus": [
+            2,
+            3
+        ],
+        "distance": 2000,
+        "distanceType": 3,
+        "raceTrackId": 10003,
+        "slopes": [],
+        "straights": [
+            {
+                "end": 950,
+                "start": 0
+            },
+            {
+                "end": 2000,
+                "start": 1350
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10308": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 650
+            },
+            {
+                "length": 200,
+                "start": 850
+            },
+            {
+                "length": 200,
+                "start": 1450
+            },
+            {
+                "length": 200,
+                "start": 1650
+            }
+        ],
+        "course": 2,
+        "courseSetStatus": [
+            1
+        ],
+        "distance": 2200,
+        "distanceType": 3,
+        "raceTrackId": 10003,
+        "slopes": [
+            {
+                "start": 1235,
+                "length": 237,
+                "slope": 14598.359171359483
+            }
+        ],
+        "straights": [
+            {
+                "end": 650,
+                "start": 0
+            },
+            {
+                "end": 1450,
+                "start": 1050
+            },
+            {
+                "end": 2200,
+                "start": 1850
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10309": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 810
+            },
+            {
+                "length": 200,
+                "start": 1010
+            },
+            {
+                "length": 200,
+                "start": 1650
+            },
+            {
+                "length": 200,
+                "start": 1850
+            }
+        ],
+        "course": 2,
+        "courseSetStatus": [],
+        "distance": 2400,
+        "distanceType": 3,
+        "raceTrackId": 10003,
+        "slopes": [],
+        "straights": [
+            {
+                "end": 810,
+                "start": 0
+            },
+            {
+                "end": 1650,
+                "start": 1210
+            },
+            {
+                "end": 2400,
+                "start": 2050
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10310": {
+        "corners": [
+            {
+                "length": 150,
+                "start": 600
+            },
+            {
+                "length": 150,
+                "start": 750
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1200,
+        "distanceType": 1,
+        "raceTrackId": 10003,
+        "slopes": [],
+        "straights": [
+            {
+                "end": 600,
+                "start": 0
+            },
+            {
+                "end": 1200,
+                "start": 900
+            }
+        ],
+        "surface": 2,
+        "turn": 2
+    },
+    "10311": {
+        "corners": [
+            {
+                "length": 160,
+                "start": 400
+            },
+            {
+                "length": 160,
+                "start": 560
+            },
+            {
+                "length": 160,
+                "start": 1140
+            },
+            {
+                "length": 160,
+                "start": 1300
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            5
+        ],
+        "distance": 1800,
+        "distanceType": 2,
+        "raceTrackId": 10003,
+        "slopes": [
+            {
+                "start": 727,
+                "length": 5,
+                "slope": 13123.952694019863
+            },
+            {
+                "start": 755,
+                "length": 31,
+                "slope": -11361.85097906242
+            },
+            {
+                "start": 1259,
+                "length": 121,
+                "slope": 15623.793490356129
+            }
+        ],
+        "straights": [
+            {
+                "end": 400,
+                "start": 0
+            },
+            {
+                "end": 1140,
+                "start": 720
+            },
+            {
+                "end": 1800,
+                "start": 1460
+            }
+        ],
+        "surface": 2,
+        "turn": 2
+    },
+    "10312": {
+        "corners": [
+            {
+                "length": 160,
+                "start": 380
+            },
+            {
+                "length": 160,
+                "start": 540
+            },
+            {
+                "length": 160,
+                "start": 1120
+            },
+            {
+                "length": 160,
+                "start": 1280
+            },
+            {
+                "length": 160,
+                "start": 1850
+            },
+            {
+                "length": 160,
+                "start": 2010
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 2500,
+        "distanceType": 4,
+        "raceTrackId": 10003,
+        "slopes": [
+            {
+                "start": 502,
+                "length": 118,
+                "slope": 14686.274488490442
+            },
+            {
+                "start": 1968,
+                "length": 118,
+                "slope": 14729.297297497436
+            }
+        ],
+        "straights": [
+            {
+                "end": 380,
+                "start": 0
+            },
+            {
+                "end": 1120,
+                "start": 700
+            },
+            {
+                "end": 1850,
+                "start": 1440
+            },
+            {
+                "end": 2500,
+                "start": 2170
+            }
+        ],
+        "surface": 2,
+        "turn": 2
+    },
+    "10401": {
+        "corners": [
+            {
+                "length": 300,
+                "start": 420
+            },
+            {
+                "length": 200,
+                "start": 720
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1200,
+        "distanceType": 1,
+        "raceTrackId": 10004,
+        "slopes": [
+            {
+                "start": 179,
+                "length": 110,
+                "slope": 14609.331905840907
+            }
+        ],
+        "straights": [
+            {
+                "end": 420,
+                "start": 0
+            },
+            {
+                "end": 1200,
+                "start": 920
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10402": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 330
+            },
+            {
+                "length": 200,
+                "start": 530
+            },
+            {
+                "length": 300,
+                "start": 1020
+            },
+            {
+                "length": 200,
+                "start": 1320
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            2
+        ],
+        "distance": 1800,
+        "distanceType": 2,
+        "raceTrackId": 10004,
+        "slopes": [
+            {
+                "start": 71,
+                "length": 52,
+                "slope": 11489.510495665016
+            },
+            {
+                "start": 790,
+                "length": 85,
+                "slope": 14877.228791094838
+            },
+            {
+                "start": 1656,
+                "length": 62,
+                "slope": 13596.2834521564
+            },
+            {
+                "start": 1744,
+                "length": 26,
+                "slope": 11639.332172552295
+            }
+        ],
+        "straights": [
+            {
+                "end": 330,
+                "start": 0
+            },
+            {
+                "end": 1020,
+                "start": 730
+            },
+            {
+                "end": 1800,
+                "start": 1520
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10403": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 530
+            },
+            {
+                "length": 200,
+                "start": 730
+            },
+            {
+                "length": 300,
+                "start": 1220
+            },
+            {
+                "length": 200,
+                "start": 1520
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            2
+        ],
+        "distance": 2000,
+        "distanceType": 3,
+        "raceTrackId": 10004,
+        "slopes": [
+            {
+                "start": 243,
+                "length": 7,
+                "slope": 10180.232873211338
+            },
+            {
+                "start": 258,
+                "length": 10,
+                "slope": 11189.921344335184
+            },
+            {
+                "start": 505,
+                "length": 34,
+                "slope": -10238.790853016375
+            },
+            {
+                "start": 989,
+                "length": 85,
+                "slope": 16947.568045831576
+            },
+            {
+                "start": 1829,
+                "length": 9,
+                "slope": 10567.632783605504
+            },
+            {
+                "start": 1939,
+                "length": 9,
+                "slope": 11232.61768948195
+            }
+        ],
+        "straights": [
+            {
+                "end": 530,
+                "start": 0
+            },
+            {
+                "end": 1220,
+                "start": 930
+            },
+            {
+                "end": 2000,
+                "start": 1720
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10404": {
+        "corners": [
+            {
+                "length": 300,
+                "start": 220
+            },
+            {
+                "length": 200,
+                "start": 520
+            },
+            {
+                "length": 200,
+                "start": 1130
+            },
+            {
+                "length": 200,
+                "start": 1330
+            },
+            {
+                "length": 300,
+                "start": 1820
+            },
+            {
+                "length": 200,
+                "start": 2120
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 2600,
+        "distanceType": 4,
+        "raceTrackId": 10004,
+        "slopes": [
+            {
+                "start": 941,
+                "length": 8,
+                "slope": 10310.527598657683
+            },
+            {
+                "start": 1604,
+                "length": 62,
+                "slope": 14203.253242134619
+            },
+            {
+                "start": 1698,
+                "length": 32,
+                "slope": 11059.696039936845
+            },
+            {
+                "start": 2540,
+                "length": 32,
+                "slope": 12901.58900524055
+            }
+        ],
+        "straights": [
+            {
+                "end": 220,
+                "start": 0
+            },
+            {
+                "end": 1130,
+                "start": 720
+            },
+            {
+                "end": 1820,
+                "start": 1530
+            },
+            {
+                "end": 2600,
+                "start": 2320
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10405": {
+        "corners": [
+            {
+                "length": 210,
+                "start": 500
+            },
+            {
+                "length": 160,
+                "start": 710
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1150,
+        "distanceType": 1,
+        "raceTrackId": 10004,
+        "slopes": [
+            {
+                "start": 220,
+                "length": 34,
+                "slope": 10306.810108378832
+            },
+            {
+                "start": 899,
+                "length": 2,
+                "slope": -12164.854440936499
+            }
+        ],
+        "straights": [
+            {
+                "end": 500,
+                "start": 0
+            },
+            {
+                "end": 1150,
+                "start": 870
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10406": {
+        "corners": [
+            {
+                "length": 170,
+                "start": 360
+            },
+            {
+                "length": 170,
+                "start": 530
+            },
+            {
+                "length": 210,
+                "start": 1050
+            },
+            {
+                "length": 160,
+                "start": 1260
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            3
+        ],
+        "distance": 1700,
+        "distanceType": 2,
+        "raceTrackId": 10004,
+        "slopes": [
+            {
+                "start": 1487,
+                "length": 37,
+                "slope": 14478.120247496146
+            },
+            {
+                "start": 1528,
+                "length": 85,
+                "slope": 16191.30014249566
+            }
+        ],
+        "straights": [
+            {
+                "end": 360,
+                "start": 0
+            },
+            {
+                "end": 1050,
+                "start": 700
+            },
+            {
+                "end": 1700,
+                "start": 1420
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10407": {
+        "corners": [
+            {
+                "length": 210,
+                "start": 310
+            },
+            {
+                "length": 160,
+                "start": 520
+            },
+            {
+                "length": 170,
+                "start": 1060
+            },
+            {
+                "length": 170,
+                "start": 1230
+            },
+            {
+                "length": 210,
+                "start": 1750
+            },
+            {
+                "length": 160,
+                "start": 1960
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            2
+        ],
+        "distance": 2400,
+        "distanceType": 3,
+        "raceTrackId": 10004,
+        "slopes": [
+            {
+                "start": 665,
+                "length": 41,
+                "slope": -12477.86502108696
+            },
+            {
+                "start": 715,
+                "length": 6,
+                "slope": 11548.05815701408
+            },
+            {
+                "start": 1065,
+                "length": 76,
+                "slope": -10974.069084446937
+            },
+            {
+                "start": 2104,
+                "length": 40,
+                "slope": -12086.188898846149
+            },
+            {
+                "start": 2153,
+                "length": 5,
+                "slope": 11312.290014552802
+            }
+        ],
+        "straights": [
+            {
+                "end": 310,
+                "start": 0
+            },
+            {
+                "end": 1060,
+                "start": 680
+            },
+            {
+                "end": 1750,
+                "start": 1400
+            },
+            {
+                "end": 2400,
+                "start": 2120
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10501": {
+        "corners": [
+            {
+                "length": 350,
+                "start": 300
+            },
+            {
+                "length": 250,
+                "start": 650
+            }
+        ],
+        "course": 3,
+        "courseSetStatus": [],
+        "distance": 1200,
+        "distanceType": 1,
+        "raceTrackId": 10005,
+        "slopes": [
+            {
+                "start": 989,
+                "length": 127,
+                "slope": 21088.359869318283
+            },
+            {
+                "start": 1136,
+                "length": 23,
+                "slope": -10863.028289065298
+            }
+        ],
+        "straights": [
+            {
+                "end": 1200,
+                "start": 900
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10502": {
+        "corners": [
+            {
+                "length": 450,
+                "start": 50
+            },
+            {
+                "length": 350,
+                "start": 700
+            },
+            {
+                "length": 250,
+                "start": 1050
+            }
+        ],
+        "course": 3,
+        "courseSetStatus": [
+            3
+        ],
+        "distance": 1600,
+        "distanceType": 2,
+        "raceTrackId": 10005,
+        "slopes": [
+            {
+                "start": 428,
+                "length": 40,
+                "slope": -10211.174741836965
+            },
+            {
+                "start": 516,
+                "length": 120,
+                "slope": -10770.051474352502
+            },
+            {
+                "start": 1395,
+                "length": 123,
+                "slope": 20820.16482922678
+            },
+            {
+                "start": 1538,
+                "length": 21,
+                "slope": -10661.219913279016
+            }
+        ],
+        "straights": [
+            {
+                "end": 1600,
+                "start": 1300
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10503": {
+        "corners": [
+            {
+                "length": 250,
+                "start": 175
+            },
+            {
+                "length": 250,
+                "start": 425
+            },
+            {
+                "length": 250,
+                "start": 1000
+            },
+            {
+                "length": 250,
+                "start": 1250
+            }
+        ],
+        "course": 2,
+        "courseSetStatus": [],
+        "distance": 1800,
+        "distanceType": 2,
+        "raceTrackId": 10005,
+        "slopes": [
+            {
+                "start": 186,
+                "length": 153,
+                "slope": 17178.162093529507
+            },
+            {
+                "start": 584,
+                "length": 113,
+                "slope": -13456.321882282167
+            },
+            {
+                "start": 749,
+                "length": 61,
+                "slope": -12337.192424818626
+            },
+            {
+                "start": 820,
+                "length": 29,
+                "slope": -11079.98155362739
+            },
+            {
+                "start": 1087,
+                "length": 37,
+                "slope": -11428.502769869006
+            },
+            {
+                "start": 1594,
+                "length": 124,
+                "slope": 21005.444829378706
+            },
+            {
+                "start": 1738,
+                "length": 21,
+                "slope": -10668.27940380635
+            }
+        ],
+        "straights": [
+            {
+                "end": 175,
+                "start": 0
+            },
+            {
+                "end": 1000,
+                "start": 675
+            },
+            {
+                "end": 1800,
+                "start": 1500
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10504": {
+        "corners": [
+            {
+                "length": 250,
+                "start": 375
+            },
+            {
+                "length": 250,
+                "start": 625
+            },
+            {
+                "length": 250,
+                "start": 1200
+            },
+            {
+                "length": 250,
+                "start": 1450
+            }
+        ],
+        "course": 2,
+        "courseSetStatus": [
+            1
+        ],
+        "distance": 2000,
+        "distanceType": 3,
+        "raceTrackId": 10005,
+        "slopes": [
+            {
+                "start": 122,
+                "length": 102,
+                "slope": 24991.80169399902
+            },
+            {
+                "start": 381,
+                "length": 154,
+                "slope": 17101.57810220412
+            },
+            {
+                "start": 781,
+                "length": 113,
+                "slope": -13464.950727730758
+            },
+            {
+                "start": 946,
+                "length": 62,
+                "slope": -12307.298449896116
+            },
+            {
+                "start": 1017,
+                "length": 29,
+                "slope": -11081.147406275955
+            },
+            {
+                "start": 1284,
+                "length": 39,
+                "slope": -11698.691455465854
+            },
+            {
+                "start": 1817,
+                "length": 100,
+                "slope": 25227.82430624795
+            },
+            {
+                "start": 1939,
+                "length": 18,
+                "slope": -10449.450456666505
+            }
+        ],
+        "straights": [
+            {
+                "end": 375,
+                "start": 0
+            },
+            {
+                "end": 1200,
+                "start": 875
+            },
+            {
+                "end": 2000,
+                "start": 1700
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10505": {
+        "corners": [
+            {
+                "length": 247,
+                "start": 403
+            },
+            {
+                "length": 450,
+                "start": 650
+            },
+            {
+                "length": 350,
+                "start": 1300
+            },
+            {
+                "length": 250,
+                "start": 1650
+            }
+        ],
+        "course": 3,
+        "courseSetStatus": [
+            2,
+            4
+        ],
+        "distance": 2200,
+        "distanceType": 3,
+        "raceTrackId": 10005,
+        "slopes": [
+            {
+                "start": 109,
+                "length": 127,
+                "slope": 21177.921222631485
+            },
+            {
+                "start": 392,
+                "length": 157,
+                "slope": 17810.87826031241
+            },
+            {
+                "start": 947,
+                "length": 93,
+                "slope": -11935.07078681866
+            },
+            {
+                "start": 1992,
+                "length": 127,
+                "slope": 20939.05549994928
+            }
+        ],
+        "straights": [
+            {
+                "end": 403,
+                "start": 0
+            },
+            {
+                "end": 2200,
+                "start": 1900
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10506": {
+        "corners": [
+            {
+                "length": 146,
+                "start": 100
+            },
+            {
+                "length": 250,
+                "start": 246
+            },
+            {
+                "length": 250,
+                "start": 875
+            },
+            {
+                "length": 250,
+                "start": 1125
+            },
+            {
+                "length": 250,
+                "start": 1700
+            },
+            {
+                "length": 250,
+                "start": 1950
+            }
+        ],
+        "course": 2,
+        "courseSetStatus": [
+            2,
+            4
+        ],
+        "distance": 2500,
+        "distanceType": 4,
+        "raceTrackId": 10005,
+        "slopes": [
+            {
+                "start": 592,
+                "length": 124,
+                "slope": 20789.01714546094
+            },
+            {
+                "start": 874,
+                "length": 154,
+                "slope": 17178.554916657224
+            },
+            {
+                "start": 1276,
+                "length": 113,
+                "slope": -13483.84892604748
+            },
+            {
+                "start": 1441,
+                "length": 62,
+                "slope": -12319.3554708876
+            },
+            {
+                "start": 1513,
+                "length": 29,
+                "slope": -11084.328284107836
+            },
+            {
+                "start": 1782,
+                "length": 37,
+                "slope": -11435.820015580415
+            },
+            {
+                "start": 2293,
+                "length": 125,
+                "slope": 20876.64102975532
+            },
+            {
+                "start": 2436,
+                "length": 24,
+                "slope": -10877.243568300275
+            }
+        ],
+        "straights": [
+            {
+                "end": 875,
+                "start": 496
+            },
+            {
+                "end": 1700,
+                "start": 1375
+            },
+            {
+                "end": 2500,
+                "start": 2200
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10507": {
+        "corners": [
+            {
+                "length": 250,
+                "start": 290
+            },
+            {
+                "length": 250,
+                "start": 540
+            },
+            {
+                "length": 250,
+                "start": 1115
+            },
+            {
+                "length": 250,
+                "start": 1365
+            },
+            {
+                "length": 250,
+                "start": 1975
+            },
+            {
+                "length": 250,
+                "start": 2225
+            },
+            {
+                "length": 250,
+                "start": 2800
+            },
+            {
+                "length": 250,
+                "start": 3050
+            }
+        ],
+        "course": 2,
+        "courseSetStatus": [
+            2
+        ],
+        "distance": 3600,
+        "distanceType": 4,
+        "raceTrackId": 10005,
+        "slopes": [
+            {
+                "start": 34,
+                "length": 120,
+                "slope": 20907.94986661872
+            },
+            {
+                "start": 309,
+                "length": 153,
+                "slope": 17050.3049029563
+            },
+            {
+                "start": 707,
+                "length": 258,
+                "slope": -12832.797942614407
+            },
+            {
+                "start": 1208,
+                "length": 36,
+                "slope": -11407.589618996573
+            },
+            {
+                "start": 1712,
+                "length": 124,
+                "slope": 21086.575278375927
+            },
+            {
+                "start": 1992,
+                "length": 152,
+                "slope": 17138.928331958945
+            },
+            {
+                "start": 2389,
+                "length": 259,
+                "slope": -12814.961913313142
+            },
+            {
+                "start": 2890,
+                "length": 36,
+                "slope": -11327.3314124099
+            },
+            {
+                "start": 3395,
+                "length": 123,
+                "slope": 20504.585529266784
+            }
+        ],
+        "straights": [
+            {
+                "end": 290,
+                "start": 0
+            },
+            {
+                "end": 1115,
+                "start": 790
+            },
+            {
+                "end": 1975,
+                "start": 1615
+            },
+            {
+                "end": 2800,
+                "start": 2475
+            },
+            {
+                "end": 3600,
+                "start": 3300
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10508": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 500
+            },
+            {
+                "length": 200,
+                "start": 700
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            3
+        ],
+        "distance": 1200,
+        "distanceType": 1,
+        "raceTrackId": 10005,
+        "slopes": [
+            {
+                "start": 200,
+                "length": 188,
+                "slope": -16658.741932756773
+            },
+            {
+                "start": 989,
+                "length": 178,
+                "slope": 13644.799202773916
+            }
+        ],
+        "straights": [
+            {
+                "end": 500,
+                "start": 0
+            },
+            {
+                "end": 1200,
+                "start": 900
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10509": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 350
+            },
+            {
+                "length": 200,
+                "start": 550
+            },
+            {
+                "length": 200,
+                "start": 1100
+            },
+            {
+                "length": 200,
+                "start": 1300
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            3
+        ],
+        "distance": 1800,
+        "distanceType": 2,
+        "raceTrackId": 10005,
+        "slopes": [
+            {
+                "start": 95,
+                "length": 182,
+                "slope": 13750.522418673829
+            },
+            {
+                "start": 386,
+                "length": 141,
+                "slope": 13674.023801983383
+            },
+            {
+                "start": 791,
+                "length": 173,
+                "slope": -17557.069258452273
+            },
+            {
+                "start": 1588,
+                "length": 186,
+                "slope": 14631.5895166099
+            }
+        ],
+        "straights": [
+            {
+                "end": 350,
+                "start": 0
+            },
+            {
+                "end": 1100,
+                "start": 750
+            },
+            {
+                "end": 1800,
+                "start": 1500
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10510": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 200
+            },
+            {
+                "length": 200,
+                "start": 400
+            },
+            {
+                "length": 200,
+                "start": 950
+            },
+            {
+                "length": 200,
+                "start": 1150
+            },
+            {
+                "length": 200,
+                "start": 1700
+            },
+            {
+                "length": 200,
+                "start": 1900
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            2
+        ],
+        "distance": 2400,
+        "distanceType": 3,
+        "raceTrackId": 10005,
+        "slopes": [
+            {
+                "start": 693,
+                "length": 160,
+                "slope": 12801.460196133356
+            },
+            {
+                "start": 858,
+                "length": 20,
+                "slope": 14167.694357850134
+            },
+            {
+                "start": 975,
+                "length": 149,
+                "slope": 13739.296337102467
+            },
+            {
+                "start": 1403,
+                "length": 163,
+                "slope": -16248.268907197978
+            },
+            {
+                "start": 2193,
+                "length": 158,
+                "slope": 12616.675797665748
+            },
+            {
+                "start": 2356,
+                "length": 19,
+                "slope": 15154.224425178587
+            }
+        ],
+        "straights": [
+            {
+                "end": 200,
+                "start": 0
+            },
+            {
+                "end": 950,
+                "start": 600
+            },
+            {
+                "end": 1700,
+                "start": 1350
+            },
+            {
+                "end": 2400,
+                "start": 2100
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10511": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 300
+            },
+            {
+                "length": 200,
+                "start": 500
+            },
+            {
+                "length": 200,
+                "start": 1050
+            },
+            {
+                "length": 200,
+                "start": 1250
+            },
+            {
+                "length": 200,
+                "start": 1800
+            },
+            {
+                "length": 200,
+                "start": 2000
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 2500,
+        "distanceType": 4,
+        "raceTrackId": 10005,
+        "slopes": [
+            {
+                "start": 791,
+                "length": 38,
+                "slope": 14279.710689290103
+            },
+            {
+                "start": 898,
+                "length": 53,
+                "slope": 10870.23074197992
+            },
+            {
+                "start": 959,
+                "length": 14,
+                "slope": 13258.41740015674
+            },
+            {
+                "start": 1075,
+                "length": 151,
+                "slope": 13643.745086074377
+            },
+            {
+                "start": 1502,
+                "length": 163,
+                "slope": -16335.193325639164
+            },
+            {
+                "start": 2289,
+                "length": 39,
+                "slope": 14160.295956105125
+            },
+            {
+                "start": 2397,
+                "length": 52,
+                "slope": 10883.997680788249
+            },
+            {
+                "start": 2456,
+                "length": 16,
+                "slope": 14207.004656244286
+            }
+        ],
+        "straights": [
+            {
+                "end": 300,
+                "start": 0
+            },
+            {
+                "end": 1050,
+                "start": 700
+            },
+            {
+                "end": 1800,
+                "start": 1450
+            },
+            {
+                "end": 2500,
+                "start": 2200
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10601": {
+        "corners": [
+            {
+                "length": 275,
+                "start": 350
+            },
+            {
+                "length": 275,
+                "start": 625
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            2,
+            3
+        ],
+        "distance": 1400,
+        "distanceType": 1,
+        "raceTrackId": 10006,
+        "slopes": [
+            {
+                "start": 134,
+                "length": 78,
+                "slope": 16252.76486295302
+            },
+            {
+                "start": 223,
+                "length": 4,
+                "slope": -11679.321268797421
+            },
+            {
+                "start": 360,
+                "length": 19,
+                "slope": -10067.625214670014
+            },
+            {
+                "start": 952,
+                "length": 37,
+                "slope": 11263.329810484904
+            },
+            {
+                "start": 995,
+                "length": 99,
+                "slope": 16911.94021152291
+            }
+        ],
+        "straights": [
+            {
+                "end": 350,
+                "start": 0
+            },
+            {
+                "end": 1400,
+                "start": 900
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10602": {
+        "corners": [
+            {
+                "length": 275,
+                "start": 550
+            },
+            {
+                "length": 275,
+                "start": 825
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            2,
+            4
+        ],
+        "distance": 1600,
+        "distanceType": 2,
+        "raceTrackId": 10006,
+        "slopes": [
+            {
+                "start": 328,
+                "length": 73,
+                "slope": 17490.441706794456
+            },
+            {
+                "start": 450,
+                "length": 122,
+                "slope": -11228.133675293982
+            },
+            {
+                "start": 1155,
+                "length": 138,
+                "slope": 12640.092371723707
+            }
+        ],
+        "straights": [
+            {
+                "end": 550,
+                "start": 0
+            },
+            {
+                "end": 1600,
+                "start": 1100
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10603": {
+        "corners": [
+            {
+                "length": 250,
+                "start": 75
+            },
+            {
+                "length": 275,
+                "start": 750
+            },
+            {
+                "length": 275,
+                "start": 1025
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            1
+        ],
+        "distance": 1800,
+        "distanceType": 2,
+        "raceTrackId": 10006,
+        "slopes": [
+            {
+                "start": 534,
+                "length": 72,
+                "slope": 17328.546707114085
+            },
+            {
+                "start": 757,
+                "length": 20,
+                "slope": -10073.431791128573
+            },
+            {
+                "start": 1350,
+                "length": 38,
+                "slope": 11417.657312537089
+            },
+            {
+                "start": 1393,
+                "length": 100,
+                "slope": 16161.971741298941
+            }
+        ],
+        "straights": [
+            {
+                "end": 750,
+                "start": 325
+            },
+            {
+                "end": 1800,
+                "start": 1300
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10604": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 200
+            },
+            {
+                "length": 275,
+                "start": 950
+            },
+            {
+                "length": 275,
+                "start": 1225
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 2000,
+        "distanceType": 3,
+        "raceTrackId": 10006,
+        "slopes": [
+            {
+                "start": 747,
+                "length": 65,
+                "slope": 17956.320511551166
+            },
+            {
+                "start": 861,
+                "length": 91,
+                "slope": -12077.455152130877
+            },
+            {
+                "start": 968,
+                "length": 20,
+                "slope": -10074.950449369784
+            },
+            {
+                "start": 1554,
+                "length": 38,
+                "slope": 11347.966396822732
+            },
+            {
+                "start": 1597,
+                "length": 100,
+                "slope": 16161.973838060941
+            }
+        ],
+        "straights": [
+            {
+                "end": 950,
+                "start": 400
+            },
+            {
+                "end": 2000,
+                "start": 1500
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10605": {
+        "corners": [
+            {
+                "length": 250,
+                "start": 225
+            },
+            {
+                "length": 325,
+                "start": 475
+            },
+            {
+                "length": 275,
+                "start": 1250
+            },
+            {
+                "length": 275,
+                "start": 1525
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            3
+        ],
+        "distance": 2300,
+        "distanceType": 3,
+        "raceTrackId": 10006,
+        "slopes": [
+            {
+                "start": 1026,
+                "length": 70,
+                "slope": 16858.811068660074
+            },
+            {
+                "start": 1251,
+                "length": 28,
+                "slope": -10111.945422491326
+            },
+            {
+                "start": 1847,
+                "length": 39,
+                "slope": 11364.982475399444
+            },
+            {
+                "start": 1891,
+                "length": 100,
+                "slope": 16211.73161974994
+            }
+        ],
+        "straights": [
+            {
+                "end": 225,
+                "start": 0
+            },
+            {
+                "end": 1250,
+                "start": 800
+            },
+            {
+                "end": 2300,
+                "start": 1800
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10606": {
+        "corners": [
+            {
+                "length": 250,
+                "start": 325
+            },
+            {
+                "length": 325,
+                "start": 575
+            },
+            {
+                "length": 275,
+                "start": 1350
+            },
+            {
+                "length": 275,
+                "start": 1625
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 2400,
+        "distanceType": 3,
+        "raceTrackId": 10006,
+        "slopes": [
+            {
+                "start": 1132,
+                "length": 15,
+                "slope": 14190.653298333791
+            },
+            {
+                "start": 1160,
+                "length": 42,
+                "slope": 16622.61793061984
+            },
+            {
+                "start": 1337,
+                "length": 31,
+                "slope": -10124.287377321862
+            },
+            {
+                "start": 1955,
+                "length": 37,
+                "slope": 11751.8422316221
+            },
+            {
+                "start": 2065,
+                "length": 28,
+                "slope": 11875.955106549252
+            }
+        ],
+        "straights": [
+            {
+                "end": 325,
+                "start": 0
+            },
+            {
+                "end": 1350,
+                "start": 900
+            },
+            {
+                "end": 2400,
+                "start": 1900
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10607": {
+        "corners": [
+            {
+                "length": 250,
+                "start": 425
+            },
+            {
+                "length": 325,
+                "start": 675
+            },
+            {
+                "length": 275,
+                "start": 1450
+            },
+            {
+                "length": 275,
+                "start": 1725
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            2
+        ],
+        "distance": 2500,
+        "distanceType": 4,
+        "raceTrackId": 10006,
+        "slopes": [
+            {
+                "start": 1216,
+                "length": 77,
+                "slope": 17393.801142259596
+            },
+            {
+                "start": 1450,
+                "length": 19,
+                "slope": -10073.908975056796
+            },
+            {
+                "start": 2051,
+                "length": 140,
+                "slope": 12577.247887061416
+            }
+        ],
+        "straights": [
+            {
+                "end": 425,
+                "start": 0
+            },
+            {
+                "end": 1450,
+                "start": 1000
+            },
+            {
+                "end": 2500,
+                "start": 2000
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10608": {
+        "corners": [
+            {
+                "length": 275,
+                "start": 292
+            },
+            {
+                "length": 275,
+                "start": 567
+            },
+            {
+                "length": 250,
+                "start": 1325
+            },
+            {
+                "length": 325,
+                "start": 1575
+            },
+            {
+                "length": 275,
+                "start": 2350
+            },
+            {
+                "length": 275,
+                "start": 2625
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 3400,
+        "distanceType": 4,
+        "raceTrackId": 10006,
+        "slopes": [
+            {
+                "start": 92,
+                "length": 72,
+                "slope": 17028.727375328952
+            },
+            {
+                "start": 212,
+                "length": 121,
+                "slope": -11222.218067109237
+            },
+            {
+                "start": 902,
+                "length": 36,
+                "slope": 11143.65733827984
+            },
+            {
+                "start": 985,
+                "length": 58,
+                "slope": 12006.668369294142
+            },
+            {
+                "start": 1124,
+                "length": 190,
+                "slope": -12795.075362310912
+            },
+            {
+                "start": 2150,
+                "length": 68,
+                "slope": 16553.02391927578
+            },
+            {
+                "start": 2266,
+                "length": 91,
+                "slope": -11557.651696046563
+            },
+            {
+                "start": 2957,
+                "length": 37,
+                "slope": 11116.114087213666
+            },
+            {
+                "start": 3040,
+                "length": 57,
+                "slope": 12037.68552168011
+            }
+        ],
+        "straights": [
+            {
+                "end": 292,
+                "start": 0
+            },
+            {
+                "end": 1325,
+                "start": 842
+            },
+            {
+                "end": 2350,
+                "start": 1900
+            },
+            {
+                "end": 3400,
+                "start": 2900
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10609": {
+        "corners": [
+            {
+                "length": 225,
+                "start": 350
+            },
+            {
+                "length": 225,
+                "start": 575
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            1
+        ],
+        "distance": 1300,
+        "distanceType": 1,
+        "raceTrackId": 10006,
+        "slopes": [
+            {
+                "start": 96,
+                "length": 115,
+                "slope": 15417.846813735092
+            },
+            {
+                "start": 249,
+                "length": 51,
+                "slope": -12300.76301477201
+            },
+            {
+                "start": 1028,
+                "length": 44,
+                "slope": 10727.418215656287
+            }
+        ],
+        "straights": [
+            {
+                "end": 350,
+                "start": 0
+            },
+            {
+                "end": 1300,
+                "start": 800
+            }
+        ],
+        "surface": 2,
+        "turn": 2
+    },
+    "10610": {
+        "corners": [
+            {
+                "length": 225,
+                "start": 450
+            },
+            {
+                "length": 225,
+                "start": 675
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            2
+        ],
+        "distance": 1400,
+        "distanceType": 1,
+        "raceTrackId": 10006,
+        "slopes": [
+            {
+                "start": 175,
+                "length": 138,
+                "slope": 17718.49834324574
+            },
+            {
+                "start": 348,
+                "length": 53,
+                "slope": -12690.30714185386
+            },
+            {
+                "start": 1128,
+                "length": 44,
+                "slope": 10728.105987879035
+            }
+        ],
+        "straights": [
+            {
+                "end": 450,
+                "start": 0
+            },
+            {
+                "end": 1400,
+                "start": 900
+            }
+        ],
+        "surface": 2,
+        "turn": 2
+    },
+    "10611": {
+        "corners": [
+            {
+                "length": 225,
+                "start": 650
+            },
+            {
+                "length": 225,
+                "start": 875
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            1,
+            2
+        ],
+        "distance": 1600,
+        "distanceType": 2,
+        "raceTrackId": 10006,
+        "slopes": [
+            {
+                "start": 236,
+                "length": 3,
+                "slope": -10511.785963590699
+            },
+            {
+                "start": 252,
+                "length": 49,
+                "slope": 15125.233511295446
+            },
+            {
+                "start": 449,
+                "length": 64,
+                "slope": 12631.783723421648
+            },
+            {
+                "start": 549,
+                "length": 56,
+                "slope": -13231.896593164298
+            },
+            {
+                "start": 1277,
+                "length": 102,
+                "slope": 13785.63236277047
+            }
+        ],
+        "straights": [
+            {
+                "end": 650,
+                "start": 0
+            },
+            {
+                "end": 1600,
+                "start": 1100
+            }
+        ],
+        "surface": 2,
+        "turn": 2
+    },
+    "10612": {
+        "corners": [
+            {
+                "length": 250,
+                "start": 200
+            },
+            {
+                "length": 250,
+                "start": 450
+            },
+            {
+                "length": 225,
+                "start": 1150
+            },
+            {
+                "length": 225,
+                "start": 1375
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 2100,
+        "distanceType": 3,
+        "raceTrackId": 10006,
+        "slopes": [
+            {
+                "start": 878,
+                "length": 138,
+                "slope": 13091.241290153857
+            },
+            {
+                "start": 1052,
+                "length": 55,
+                "slope": -13047.081779551509
+            },
+            {
+                "start": 1752,
+                "length": 4,
+                "slope": 10004.647923211056
+            },
+            {
+                "start": 1877,
+                "length": 7,
+                "slope": 12648.028109330962
+            }
+        ],
+        "straights": [
+            {
+                "end": 200,
+                "start": 0
+            },
+            {
+                "end": 1150,
+                "start": 700
+            },
+            {
+                "end": 2100,
+                "start": 1600
+            }
+        ],
+        "surface": 2,
+        "turn": 2
+    },
+    "10613": {
+        "corners": [
+            {
+                "length": 250,
+                "start": 500
+            },
+            {
+                "length": 250,
+                "start": 750
+            },
+            {
+                "length": 225,
+                "start": 1450
+            },
+            {
+                "length": 225,
+                "start": 1675
+            },
+            {
+                "length": 500,
+                "start": 2348
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            2
+        ],
+        "distance": 2400,
+        "distanceType": 3,
+        "raceTrackId": 10006,
+        "slopes": [
+            {
+                "start": 57,
+                "length": 134,
+                "slope": 11963.901152971346
+            },
+            {
+                "start": 214,
+                "length": 104,
+                "slope": 42775.01098774477
+            },
+            {
+                "start": 362,
+                "length": 175,
+                "slope": 19727.53718117865
+            },
+            {
+                "start": 1345,
+                "length": 43,
+                "slope": -27742.670452214283
+            },
+            {
+                "start": 2021,
+                "length": 79,
+                "slope": 11496.402583043455
+            },
+            {
+                "start": 2193,
+                "length": 12,
+                "slope": 10085.87972959639
+            },
+            {
+                "start": 2252,
+                "length": 97,
+                "slope": -17081.25533433974
+            }
+        ],
+        "straights": [
+            {
+                "end": 500,
+                "start": 0
+            },
+            {
+                "end": 1450,
+                "start": 1000
+            },
+            {
+                "end": 2400,
+                "start": 1900
+            }
+        ],
+        "surface": 2,
+        "turn": 2
+    },
+    "10701": {
+        "corners": [
+            {
+                "length": 250,
+                "start": 300
+            },
+            {
+                "length": 250,
+                "start": 550
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1200,
+        "distanceType": 1,
+        "raceTrackId": 10007,
+        "slopes": [
+            {
+                "start": 851,
+                "length": 114,
+                "slope": 18967.378896797658
+            },
+            {
+                "start": 1030,
+                "length": 74,
+                "slope": 11808.204199219508
+            }
+        ],
+        "straights": [
+            {
+                "end": 300,
+                "start": 0
+            },
+            {
+                "end": 1200,
+                "start": 800
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10702": {
+        "corners": [
+            {
+                "length": 250,
+                "start": 500
+            },
+            {
+                "length": 250,
+                "start": 750
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1400,
+        "distanceType": 1,
+        "raceTrackId": 10007,
+        "slopes": [
+            {
+                "start": 1062,
+                "length": 117,
+                "slope": 17747.3211292392
+            },
+            {
+                "start": 1201,
+                "length": 3,
+                "slope": -10216.939990390934
+            }
+        ],
+        "straights": [
+            {
+                "end": 500,
+                "start": 0
+            },
+            {
+                "end": 1400,
+                "start": 1000
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10703": {
+        "corners": [
+            {
+                "length": 150,
+                "start": 150
+            },
+            {
+                "length": 250,
+                "start": 700
+            },
+            {
+                "length": 250,
+                "start": 950
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            1
+        ],
+        "distance": 1600,
+        "distanceType": 2,
+        "raceTrackId": 10007,
+        "slopes": [
+            {
+                "start": 1250,
+                "length": 126,
+                "slope": 18870.494856212194
+            },
+            {
+                "start": 1400,
+                "length": 2,
+                "slope": -10980.51692662582
+            }
+        ],
+        "straights": [
+            {
+                "end": 700,
+                "start": 300
+            },
+            {
+                "end": 1600,
+                "start": 1200
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10704": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 300
+            },
+            {
+                "length": 200,
+                "start": 500
+            },
+            {
+                "length": 250,
+                "start": 1100
+            },
+            {
+                "length": 250,
+                "start": 1350
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 2000,
+        "distanceType": 3,
+        "raceTrackId": 10007,
+        "slopes": [
+            {
+                "start": 95,
+                "length": 3,
+                "slope": -10769.549305262555
+            },
+            {
+                "start": 138,
+                "length": 79,
+                "slope": 11627.438552024147
+            },
+            {
+                "start": 1654,
+                "length": 123,
+                "slope": 17676.625841099984
+            }
+        ],
+        "straights": [
+            {
+                "end": 300,
+                "start": 0
+            },
+            {
+                "end": 1100,
+                "start": 700
+            },
+            {
+                "end": 2000,
+                "start": 1600
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10705": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 500
+            },
+            {
+                "length": 200,
+                "start": 700
+            },
+            {
+                "length": 250,
+                "start": 1300
+            },
+            {
+                "length": 250,
+                "start": 1550
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            2
+        ],
+        "distance": 2200,
+        "distanceType": 3,
+        "raceTrackId": 10007,
+        "slopes": [
+            {
+                "start": 160,
+                "length": 110,
+                "slope": 17500.122390925975
+            },
+            {
+                "start": 1862,
+                "length": 108,
+                "slope": 17326.651837121168
+            }
+        ],
+        "straights": [
+            {
+                "end": 500,
+                "start": 0
+            },
+            {
+                "end": 1300,
+                "start": 900
+            },
+            {
+                "end": 2200,
+                "start": 1800
+            }
+        ],
+        "surface": 1,
+        "turn": 2
+    },
+    "10706": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 400
+            },
+            {
+                "length": 200,
+                "start": 600
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1200,
+        "distanceType": 1,
+        "raceTrackId": 10007,
+        "slopes": [
+            {
+                "start": 872,
+                "length": 108,
+                "slope": 15359.154913731463
+            },
+            {
+                "start": 989,
+                "length": 2,
+                "slope": 10054.117209159976
+            }
+        ],
+        "straights": [
+            {
+                "end": 400,
+                "start": 0
+            },
+            {
+                "end": 1200,
+                "start": 800
+            }
+        ],
+        "surface": 2,
+        "turn": 2
+    },
+    "10707": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 600
+            },
+            {
+                "length": 200,
+                "start": 800
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1400,
+        "distanceType": 1,
+        "raceTrackId": 10007,
+        "slopes": [
+            {
+                "start": 1082,
+                "length": 105,
+                "slope": 13865.05748983298
+            }
+        ],
+        "straights": [
+            {
+                "end": 600,
+                "start": 0
+            },
+            {
+                "end": 1400,
+                "start": 1000
+            }
+        ],
+        "surface": 2,
+        "turn": 2
+    },
+    "10708": {
+        "corners": [
+            {
+                "length": 165,
+                "start": 270
+            },
+            {
+                "length": 165,
+                "start": 435
+            },
+            {
+                "length": 200,
+                "start": 1000
+            },
+            {
+                "length": 200,
+                "start": 1200
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            2
+        ],
+        "distance": 1800,
+        "distanceType": 2,
+        "raceTrackId": 10007,
+        "slopes": [
+            {
+                "start": 1481,
+                "length": 125,
+                "slope": 14447.7197419479
+            }
+        ],
+        "straights": [
+            {
+                "end": 270,
+                "start": 0
+            },
+            {
+                "end": 1000,
+                "start": 600
+            },
+            {
+                "end": 1800,
+                "start": 1400
+            }
+        ],
+        "surface": 2,
+        "turn": 2
+    },
+    "10709": {
+        "corners": [
+            {
+                "length": 165,
+                "start": 370
+            },
+            {
+                "length": 165,
+                "start": 535
+            },
+            {
+                "length": 200,
+                "start": 1100
+            },
+            {
+                "length": 200,
+                "start": 1300
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1900,
+        "distanceType": 3,
+        "raceTrackId": 10007,
+        "slopes": [
+            {
+                "start": 85,
+                "length": 75,
+                "slope": 10624.05137586846
+            },
+            {
+                "start": 261,
+                "length": 4,
+                "slope": 10530.987705161495
+            },
+            {
+                "start": 1571,
+                "length": 127,
+                "slope": 13501.579261859455
+            }
+        ],
+        "straights": [
+            {
+                "end": 370,
+                "start": 0
+            },
+            {
+                "end": 1100,
+                "start": 700
+            },
+            {
+                "end": 1900,
+                "start": 1500
+            }
+        ],
+        "surface": 2,
+        "turn": 2
+    },
+    "10801": {
+        "corners": [
+            {
+                "length": 275,
+                "start": 320
+            },
+            {
+                "length": 275,
+                "start": 595
+            }
+        ],
+        "course": 2,
+        "courseSetStatus": [],
+        "distance": 1200,
+        "distanceType": 1,
+        "raceTrackId": 10008,
+        "slopes": [
+            {
+                "start": 167,
+                "length": 152,
+                "slope": 19378.3025352294
+            },
+            {
+                "start": 446,
+                "length": 161,
+                "slope": -16243.640275019949
+            }
+        ],
+        "straights": [
+            {
+                "end": 320,
+                "start": 0
+            },
+            {
+                "end": 1200,
+                "start": 870
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10802": {
+        "corners": [
+            {
+                "length": 275,
+                "start": 520
+            },
+            {
+                "length": 275,
+                "start": 795
+            }
+        ],
+        "course": 2,
+        "courseSetStatus": [],
+        "distance": 1400,
+        "distanceType": 1,
+        "raceTrackId": 10008,
+        "slopes": [
+            {
+                "start": 386,
+                "length": 131,
+                "slope": 14922.919527052434
+            },
+            {
+                "start": 645,
+                "length": 161,
+                "slope": -16245.26741271931
+            }
+        ],
+        "straights": [
+            {
+                "end": 520,
+                "start": 0
+            },
+            {
+                "end": 1400,
+                "start": 1070
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10803": {
+        "corners": [
+            {
+                "length": 250,
+                "start": 500
+            },
+            {
+                "length": 250,
+                "start": 750
+            }
+        ],
+        "course": 3,
+        "courseSetStatus": [],
+        "distance": 1400,
+        "distanceType": 1,
+        "raceTrackId": 10008,
+        "slopes": [
+            {
+                "start": 268,
+                "length": 142,
+                "slope": 15393.521819802356
+            },
+            {
+                "start": 489,
+                "length": 6,
+                "slope": -10249.801772385132
+            },
+            {
+                "start": 507,
+                "length": 39,
+                "slope": 22518.486356106492
+            },
+            {
+                "start": 573,
+                "length": 168,
+                "slope": -23433.120477758912
+            }
+        ],
+        "straights": [
+            {
+                "end": 500,
+                "start": 0
+            },
+            {
+                "end": 1400,
+                "start": 1000
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10804": {
+        "corners": [
+            {
+                "length": 275,
+                "start": 720
+            },
+            {
+                "length": 275,
+                "start": 995
+            }
+        ],
+        "course": 2,
+        "courseSetStatus": [
+            1
+        ],
+        "distance": 1600,
+        "distanceType": 2,
+        "raceTrackId": 10008,
+        "slopes": [
+            {
+                "start": 552,
+                "length": 128,
+                "slope": 14674.391739048284
+            },
+            {
+                "start": 813,
+                "length": 168,
+                "slope": -16234.227123305245
+            }
+        ],
+        "straights": [
+            {
+                "end": 720,
+                "start": 200
+            },
+            {
+                "end": 1600,
+                "start": 1270
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10805": {
+        "corners": [
+            {
+                "length": 250,
+                "start": 700
+            },
+            {
+                "length": 250,
+                "start": 950
+            }
+        ],
+        "course": 3,
+        "courseSetStatus": [
+            1
+        ],
+        "distance": 1600,
+        "distanceType": 2,
+        "raceTrackId": 10008,
+        "slopes": [
+            {
+                "start": 463,
+                "length": 182,
+                "slope": 16543.713742138785
+            },
+            {
+                "start": 722,
+                "length": 4,
+                "slope": -10359.025326984814
+            },
+            {
+                "start": 739,
+                "length": 38,
+                "slope": 22643.04781754876
+            },
+            {
+                "start": 802,
+                "length": 162,
+                "slope": -23588.982173657412
+            }
+        ],
+        "straights": [
+            {
+                "end": 700,
+                "start": 200
+            },
+            {
+                "end": 1600,
+                "start": 1200
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10806": {
+        "corners": [
+            {
+                "length": 250,
+                "start": 900
+            },
+            {
+                "length": 250,
+                "start": 1150
+            }
+        ],
+        "course": 3,
+        "courseSetStatus": [],
+        "distance": 1800,
+        "distanceType": 2,
+        "raceTrackId": 10008,
+        "slopes": [
+            {
+                "start": 646,
+                "length": 182,
+                "slope": 16919.851977912487
+            },
+            {
+                "start": 923,
+                "length": 45,
+                "slope": 22187.46904941495
+            },
+            {
+                "start": 990,
+                "length": 164,
+                "slope": -23542.658605764354
+            }
+        ],
+        "straights": [
+            {
+                "end": 900,
+                "start": 400
+            },
+            {
+                "end": 1800,
+                "start": 1400
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10807": {
+        "corners": [
+            {
+                "length": 185,
+                "start": 400
+            },
+            {
+                "length": 185,
+                "start": 585
+            },
+            {
+                "length": 250,
+                "start": 1170
+            },
+            {
+                "length": 250,
+                "start": 1420
+            }
+        ],
+        "course": 2,
+        "courseSetStatus": [
+            3
+        ],
+        "distance": 2000,
+        "distanceType": 3,
+        "raceTrackId": 10008,
+        "slopes": [
+            {
+                "start": 1045,
+                "length": 114,
+                "slope": 14977.787009357296
+            },
+            {
+                "start": 1280,
+                "length": 154,
+                "slope": -16493.81272702919
+            }
+        ],
+        "straights": [
+            {
+                "end": 400,
+                "start": 0
+            },
+            {
+                "end": 1170,
+                "start": 770
+            },
+            {
+                "end": 2000,
+                "start": 1670
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10808": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 400
+            },
+            {
+                "length": 200,
+                "start": 600
+            },
+            {
+                "length": 250,
+                "start": 1300
+            },
+            {
+                "length": 250,
+                "start": 1550
+            }
+        ],
+        "course": 3,
+        "courseSetStatus": [
+            1
+        ],
+        "distance": 2200,
+        "distanceType": 3,
+        "raceTrackId": 10008,
+        "slopes": [
+            {
+                "start": 1038,
+                "length": 180,
+                "slope": 17169.220114259668
+            },
+            {
+                "start": 1318,
+                "length": 47,
+                "slope": 20040.646584847855
+            },
+            {
+                "start": 1383,
+                "length": 167,
+                "slope": -23602.339219520214
+            }
+        ],
+        "straights": [
+            {
+                "end": 400,
+                "start": 0
+            },
+            {
+                "end": 1300,
+                "start": 800
+            },
+            {
+                "end": 2200,
+                "start": 1800
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10809": {
+        "corners": [
+            {
+                "length": 200,
+                "start": 600
+            },
+            {
+                "length": 200,
+                "start": 800
+            },
+            {
+                "length": 250,
+                "start": 1500
+            },
+            {
+                "length": 250,
+                "start": 1750
+            }
+        ],
+        "course": 3,
+        "courseSetStatus": [
+            3
+        ],
+        "distance": 2400,
+        "distanceType": 3,
+        "raceTrackId": 10008,
+        "slopes": [
+            {
+                "start": 1240,
+                "length": 182,
+                "slope": 16815.62933977
+            },
+            {
+                "start": 1502,
+                "length": 7,
+                "slope": -10488.591385021755
+            },
+            {
+                "start": 1521,
+                "length": 47,
+                "slope": 22704.71090978517
+            },
+            {
+                "start": 1585,
+                "length": 166,
+                "slope": -24025.448472426408
+            }
+        ],
+        "straights": [
+            {
+                "end": 600,
+                "start": 0
+            },
+            {
+                "end": 1500,
+                "start": 1000
+            },
+            {
+                "end": 2400,
+                "start": 2000
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10810": {
+        "corners": [
+            {
+                "length": 250,
+                "start": 261
+            },
+            {
+                "length": 250,
+                "start": 511
+            },
+            {
+                "length": 200,
+                "start": 1250
+            },
+            {
+                "length": 200,
+                "start": 1450
+            },
+            {
+                "length": 250,
+                "start": 2100
+            },
+            {
+                "length": 250,
+                "start": 2350
+            }
+        ],
+        "course": 3,
+        "courseSetStatus": [
+            3,
+            5
+        ],
+        "distance": 3000,
+        "distanceType": 4,
+        "raceTrackId": 10008,
+        "slopes": [
+            {
+                "start": 21,
+                "length": 178,
+                "slope": 19798.18021261757
+            },
+            {
+                "start": 279,
+                "length": 5,
+                "slope": -10110.222966701731
+            },
+            {
+                "start": 297,
+                "length": 45,
+                "slope": 23107.50728706
+            },
+            {
+                "start": 361,
+                "length": 162,
+                "slope": -23628.24058720927
+            },
+            {
+                "start": 1857,
+                "length": 179,
+                "slope": 16751.337046764864
+            },
+            {
+                "start": 2117,
+                "length": 4,
+                "slope": -10128.53395171957
+            },
+            {
+                "start": 2134,
+                "length": 45,
+                "slope": 22550.316354863815
+            },
+            {
+                "start": 2198,
+                "length": 163,
+                "slope": -23576.572682858376
+            }
+        ],
+        "straights": [
+            {
+                "end": 261,
+                "start": 0
+            },
+            {
+                "end": 1250,
+                "start": 761
+            },
+            {
+                "end": 2100,
+                "start": 1650
+            },
+            {
+                "end": 3000,
+                "start": 2600
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10811": {
+        "corners": [
+            {
+                "length": 250,
+                "start": 458
+            },
+            {
+                "length": 250,
+                "start": 708
+            },
+            {
+                "length": 200,
+                "start": 1450
+            },
+            {
+                "length": 200,
+                "start": 1650
+            },
+            {
+                "length": 250,
+                "start": 2300
+            },
+            {
+                "length": 250,
+                "start": 2550
+            }
+        ],
+        "course": 3,
+        "courseSetStatus": [],
+        "distance": 3200,
+        "distanceType": 4,
+        "raceTrackId": 10008,
+        "slopes": [
+            {
+                "start": 215,
+                "length": 181,
+                "slope": 16705.24699992756
+            },
+            {
+                "start": 476,
+                "length": 3,
+                "slope": -10182.787858575715
+            },
+            {
+                "start": 493,
+                "length": 36,
+                "slope": 23600.98533606718
+            },
+            {
+                "start": 556,
+                "length": 164,
+                "slope": -23563.194888626876
+            },
+            {
+                "start": 2055,
+                "length": 181,
+                "slope": 16705.126009114043
+            },
+            {
+                "start": 2316,
+                "length": 3,
+                "slope": -10184.39321121843
+            },
+            {
+                "start": 2333,
+                "length": 36,
+                "slope": 23627.51745296099
+            },
+            {
+                "start": 2396,
+                "length": 164,
+                "slope": -23562.618021432423
+            }
+        ],
+        "straights": [
+            {
+                "end": 458,
+                "start": 0
+            },
+            {
+                "end": 1450,
+                "start": 958
+            },
+            {
+                "end": 2300,
+                "start": 1850
+            },
+            {
+                "end": 3200,
+                "start": 2800
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10812": {
+        "corners": [
+            {
+                "length": 225,
+                "start": 400
+            },
+            {
+                "length": 225,
+                "start": 625
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1200,
+        "distanceType": 1,
+        "raceTrackId": 10008,
+        "slopes": [
+            {
+                "start": 245,
+                "length": 157,
+                "slope": 16863.6865674206
+            },
+            {
+                "start": 471,
+                "length": 102,
+                "slope": -14780.13549936777
+            }
+        ],
+        "straights": [
+            {
+                "end": 400,
+                "start": 0
+            },
+            {
+                "end": 1200,
+                "start": 850
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10813": {
+        "corners": [
+            {
+                "length": 225,
+                "start": 600
+            },
+            {
+                "length": 225,
+                "start": 825
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1400,
+        "distanceType": 1,
+        "raceTrackId": 10008,
+        "slopes": [
+            {
+                "start": 477,
+                "length": 140,
+                "slope": 17189.16216130649
+            },
+            {
+                "start": 693,
+                "length": 190,
+                "slope": -12970.357582265451
+            }
+        ],
+        "straights": [
+            {
+                "end": 600,
+                "start": 100
+            },
+            {
+                "end": 1400,
+                "start": 1050
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10814": {
+        "corners": [
+            {
+                "length": 150,
+                "start": 300
+            },
+            {
+                "length": 150,
+                "start": 450
+            },
+            {
+                "length": 225,
+                "start": 1000
+            },
+            {
+                "length": 225,
+                "start": 1225
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1800,
+        "distanceType": 2,
+        "raceTrackId": 10008,
+        "slopes": [
+            {
+                "start": 837,
+                "length": 168,
+                "slope": 19481.409973602193
+            },
+            {
+                "start": 1079,
+                "length": 96,
+                "slope": -17841.784747871447
+            }
+        ],
+        "straights": [
+            {
+                "end": 300,
+                "start": 0
+            },
+            {
+                "end": 1000,
+                "start": 600
+            },
+            {
+                "end": 1800,
+                "start": 1450
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10815": {
+        "corners": [
+            {
+                "length": 150,
+                "start": 400
+            },
+            {
+                "length": 150,
+                "start": 550
+            },
+            {
+                "length": 225,
+                "start": 1100
+            },
+            {
+                "length": 225,
+                "start": 1325
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1900,
+        "distanceType": 3,
+        "raceTrackId": 10008,
+        "slopes": [
+            {
+                "start": 940,
+                "length": 168,
+                "slope": 18283.781247768184
+            },
+            {
+                "start": 1188,
+                "length": 195,
+                "slope": -14402.11636525795
+            }
+        ],
+        "straights": [
+            {
+                "end": 400,
+                "start": 0
+            },
+            {
+                "end": 1100,
+                "start": 700
+            },
+            {
+                "end": 1900,
+                "start": 1550
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10901": {
+        "corners": [
+            {
+                "length": 300,
+                "start": 250
+            },
+            {
+                "length": 300,
+                "start": 550
+            }
+        ],
+        "course": 2,
+        "courseSetStatus": [],
+        "distance": 1200,
+        "distanceType": 1,
+        "raceTrackId": 10009,
+        "slopes": [
+            {
+                "start": 1012,
+                "length": 114,
+                "slope": 15108.698657879435
+            },
+            {
+                "start": 1129,
+                "length": 11,
+                "slope": 12919.742062984498
+            }
+        ],
+        "straights": [
+            {
+                "end": 250,
+                "start": 0
+            },
+            {
+                "end": 1200,
+                "start": 850
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10902": {
+        "corners": [
+            {
+                "length": 300,
+                "start": 450
+            },
+            {
+                "length": 300,
+                "start": 750
+            }
+        ],
+        "course": 2,
+        "courseSetStatus": [],
+        "distance": 1400,
+        "distanceType": 1,
+        "raceTrackId": 10009,
+        "slopes": [
+            {
+                "start": 1212,
+                "length": 116,
+                "slope": 14976.926550616625
+            },
+            {
+                "start": 1328,
+                "length": 12,
+                "slope": 12993.502603808056
+            }
+        ],
+        "straights": [
+            {
+                "end": 450,
+                "start": 0
+            },
+            {
+                "end": 1400,
+                "start": 1050
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10903": {
+        "corners": [
+            {
+                "length": 350,
+                "start": 450
+            },
+            {
+                "length": 350,
+                "start": 800
+            }
+        ],
+        "course": 3,
+        "courseSetStatus": [
+            3
+        ],
+        "distance": 1600,
+        "distanceType": 2,
+        "raceTrackId": 10009,
+        "slopes": [
+            {
+                "start": 363,
+                "length": 22,
+                "slope": 11141.063686653439
+            },
+            {
+                "start": 1411,
+                "length": 114,
+                "slope": 15251.135124038405
+            },
+            {
+                "start": 1528,
+                "length": 12,
+                "slope": 12509.843450900318
+            }
+        ],
+        "straights": [
+            {
+                "end": 450,
+                "start": 0
+            },
+            {
+                "end": 1600,
+                "start": 1150
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10904": {
+        "corners": [
+            {
+                "length": 350,
+                "start": 650
+            },
+            {
+                "length": 350,
+                "start": 1000
+            }
+        ],
+        "course": 3,
+        "courseSetStatus": [
+            3
+        ],
+        "distance": 1800,
+        "distanceType": 2,
+        "raceTrackId": 10009,
+        "slopes": [
+            {
+                "start": 569,
+                "length": 22,
+                "slope": 11121.157347994003
+            },
+            {
+                "start": 1611,
+                "length": 129,
+                "slope": 14727.337771174274
+            }
+        ],
+        "straights": [
+            {
+                "end": 650,
+                "start": 0
+            },
+            {
+                "end": 1800,
+                "start": 1350
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10905": {
+        "corners": [
+            {
+                "length": 190,
+                "start": 370
+            },
+            {
+                "length": 190,
+                "start": 560
+            },
+            {
+                "length": 300,
+                "start": 1050
+            },
+            {
+                "length": 300,
+                "start": 1350
+            }
+        ],
+        "course": 2,
+        "courseSetStatus": [
+            4
+        ],
+        "distance": 2000,
+        "distanceType": 3,
+        "raceTrackId": 10009,
+        "slopes": [
+            {
+                "start": 163,
+                "length": 113,
+                "slope": 15220.414823767574
+            },
+            {
+                "start": 279,
+                "length": 11,
+                "slope": 13126.63971671884
+            },
+            {
+                "start": 1813,
+                "length": 113,
+                "slope": 15141.473855088745
+            },
+            {
+                "start": 1929,
+                "length": 12,
+                "slope": 12552.182074656168
+            }
+        ],
+        "straights": [
+            {
+                "end": 370,
+                "start": 0
+            },
+            {
+                "end": 1050,
+                "start": 750
+            },
+            {
+                "end": 2000,
+                "start": 1650
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10906": {
+        "corners": [
+            {
+                "length": 190,
+                "start": 520
+            },
+            {
+                "length": 190,
+                "start": 710
+            },
+            {
+                "length": 300,
+                "start": 1250
+            },
+            {
+                "length": 300,
+                "start": 1550
+            }
+        ],
+        "course": 2,
+        "courseSetStatus": [
+            1
+        ],
+        "distance": 2200,
+        "distanceType": 3,
+        "raceTrackId": 10009,
+        "slopes": [
+            {
+                "start": 310,
+                "length": 116,
+                "slope": 15230.47201687792
+            },
+            {
+                "start": 430,
+                "length": 11,
+                "slope": 13141.7643011536
+            },
+            {
+                "start": 2007,
+                "length": 116,
+                "slope": 15142.497852776145
+            },
+            {
+                "start": 2127,
+                "length": 12,
+                "slope": 12738.6653432378
+            }
+        ],
+        "straights": [
+            {
+                "end": 520,
+                "start": 0
+            },
+            {
+                "end": 1250,
+                "start": 900
+            },
+            {
+                "end": 2200,
+                "start": 1850
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10907": {
+        "corners": [
+            {
+                "length": 190,
+                "start": 382
+            },
+            {
+                "length": 190,
+                "start": 558
+            },
+            {
+                "length": 350,
+                "start": 1250
+            },
+            {
+                "length": 350,
+                "start": 1600
+            }
+        ],
+        "course": 3,
+        "courseSetStatus": [
+            3
+        ],
+        "distance": 2400,
+        "distanceType": 3,
+        "raceTrackId": 10009,
+        "slopes": [
+            {
+                "start": 163,
+                "length": 114,
+                "slope": 15190.960209841982
+            },
+            {
+                "start": 280,
+                "length": 11,
+                "slope": 13356.610788921129
+            },
+            {
+                "start": 1172,
+                "length": 22,
+                "slope": 11098.928959352259
+            },
+            {
+                "start": 2212,
+                "length": 113,
+                "slope": 15250.197111588011
+            },
+            {
+                "start": 2329,
+                "length": 11,
+                "slope": 12516.421074555561
+            }
+        ],
+        "straights": [
+            {
+                "end": 1250,
+                "start": 750
+            },
+            {
+                "end": 2400,
+                "start": 1950
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10908": {
+        "corners": [
+            {
+                "length": 190,
+                "start": 570
+            },
+            {
+                "length": 190,
+                "start": 760
+            },
+            {
+                "length": 350,
+                "start": 1450
+            },
+            {
+                "length": 350,
+                "start": 1800
+            }
+        ],
+        "course": 3,
+        "courseSetStatus": [],
+        "distance": 2600,
+        "distanceType": 4,
+        "raceTrackId": 10009,
+        "slopes": [
+            {
+                "start": 360,
+                "length": 114,
+                "slope": 15190.391311808322
+            },
+            {
+                "start": 477,
+                "length": 11,
+                "slope": 13113.58549313965
+            },
+            {
+                "start": 1370,
+                "length": 22,
+                "slope": 11081.529696479987
+            },
+            {
+                "start": 2412,
+                "length": 113,
+                "slope": 15258.73896602605
+            },
+            {
+                "start": 2529,
+                "length": 11,
+                "slope": 12955.840000889535
+            }
+        ],
+        "straights": [
+            {
+                "end": 570,
+                "start": 0
+            },
+            {
+                "end": 1450,
+                "start": 950
+            },
+            {
+                "end": 2600,
+                "start": 2150
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10909": {
+        "corners": [
+            {
+                "length": 300,
+                "start": 348
+            },
+            {
+                "length": 300,
+                "start": 648
+            },
+            {
+                "length": 190,
+                "start": 1320
+            },
+            {
+                "length": 190,
+                "start": 1510
+            },
+            {
+                "length": 300,
+                "start": 2050
+            },
+            {
+                "length": 300,
+                "start": 2350
+            }
+        ],
+        "course": 2,
+        "courseSetStatus": [
+            3
+        ],
+        "distance": 3000,
+        "distanceType": 4,
+        "raceTrackId": 10009,
+        "slopes": [
+            {
+                "start": 1107,
+                "length": 116,
+                "slope": 15149.838653967885
+            },
+            {
+                "start": 1226,
+                "length": 13,
+                "slope": 12709.6703317389
+            },
+            {
+                "start": 2807,
+                "length": 116,
+                "slope": 15148.460436499508
+            },
+            {
+                "start": 2926,
+                "length": 13,
+                "slope": 12436.067874714365
+            }
+        ],
+        "straights": [
+            {
+                "end": 348,
+                "start": 0
+            },
+            {
+                "end": 1320,
+                "start": 948
+            },
+            {
+                "end": 2050,
+                "start": 1700
+            },
+            {
+                "end": 3000,
+                "start": 2650
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "10910": {
+        "corners": [
+            {
+                "length": 250,
+                "start": 350
+            },
+            {
+                "length": 250,
+                "start": 600
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1200,
+        "distanceType": 1,
+        "raceTrackId": 10009,
+        "slopes": [
+            {
+                "start": 1110,
+                "length": 59,
+                "slope": 12347.434135345244
+            }
+        ],
+        "straights": [
+            {
+                "end": 350,
+                "start": 0
+            },
+            {
+                "end": 1200,
+                "start": 850
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10911": {
+        "corners": [
+            {
+                "length": 250,
+                "start": 550
+            },
+            {
+                "length": 250,
+                "start": 800
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1400,
+        "distanceType": 1,
+        "raceTrackId": 10009,
+        "slopes": [
+            {
+                "start": 441,
+                "length": 56,
+                "slope": -11899.53010640554
+            },
+            {
+                "start": 1310,
+                "length": 59,
+                "slope": 12346.801747018537
+            }
+        ],
+        "straights": [
+            {
+                "end": 550,
+                "start": 0
+            },
+            {
+                "end": 1400,
+                "start": 1050
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10912": {
+        "corners": [
+            {
+                "length": 150,
+                "start": 330
+            },
+            {
+                "length": 150,
+                "start": 480
+            },
+            {
+                "length": 250,
+                "start": 950
+            },
+            {
+                "length": 250,
+                "start": 1200
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1800,
+        "distanceType": 2,
+        "raceTrackId": 10009,
+        "slopes": [
+            {
+                "start": 221,
+                "length": 54,
+                "slope": 12119.429477668806
+            },
+            {
+                "start": 1710,
+                "length": 59,
+                "slope": 12340.655078339623
+            }
+        ],
+        "straights": [
+            {
+                "end": 330,
+                "start": 0
+            },
+            {
+                "end": 950,
+                "start": 630
+            },
+            {
+                "end": 1800,
+                "start": 1449
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10913": {
+        "corners": [
+            {
+                "length": 150,
+                "start": 500
+            },
+            {
+                "length": 150,
+                "start": 650
+            },
+            {
+                "length": 250,
+                "start": 1150
+            },
+            {
+                "length": 250,
+                "start": 1400
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            2,
+            3
+        ],
+        "distance": 2000,
+        "distanceType": 3,
+        "raceTrackId": 10009,
+        "slopes": [
+            {
+                "start": 373,
+                "length": 47,
+                "slope": 10791.623402670139
+            },
+            {
+                "start": 517,
+                "length": 112,
+                "slope": 18091.521927762085
+            },
+            {
+                "start": 1907,
+                "length": 61,
+                "slope": 12312.279266997792
+            }
+        ],
+        "straights": [
+            {
+                "end": 500,
+                "start": 0
+            },
+            {
+                "end": 1150,
+                "start": 800
+            },
+            {
+                "end": 2000,
+                "start": 1650
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "10914": {
+        "corners": [
+            {
+                "length": 350,
+                "start": 370
+            },
+            {
+                "length": 350,
+                "start": 720
+            },
+            {
+                "length": 190,
+                "start": 1520
+            },
+            {
+                "length": 190,
+                "start": 1710
+            },
+            {
+                "length": 300,
+                "start": 2250
+            },
+            {
+                "length": 300,
+                "start": 2550
+            }
+        ],
+        "course": 4,
+        "courseSetStatus": [],
+        "distance": 3200,
+        "distanceType": 4,
+        "raceTrackId": 10009,
+        "slopes": [
+            {
+                "start": 298,
+                "length": 24,
+                "slope": 10983.052656874046
+            },
+            {
+                "start": 1344,
+                "length": 114,
+                "slope": 15323.662947570821
+            },
+            {
+                "start": 1461,
+                "length": 11,
+                "slope": 13226.775713577295
+            },
+            {
+                "start": 1695,
+                "length": 43,
+                "slope": 10068.848419855183
+            },
+            {
+                "start": 3011,
+                "length": 114,
+                "slope": 15230.71411911918
+            },
+            {
+                "start": 3128,
+                "length": 10,
+                "slope": 12726.102814786685
+            }
+        ],
+        "straights": [
+            {
+                "end": 370,
+                "start": 0
+            },
+            {
+                "end": 1520,
+                "start": 1070
+            },
+            {
+                "end": 2250,
+                "start": 1900
+            },
+            {
+                "end": 3200,
+                "start": 2850
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "11001": {
+        "corners": [
+            {
+                "length": 205,
+                "start": 500
+            },
+            {
+                "length": 205,
+                "start": 705
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            1
+        ],
+        "distance": 1200,
+        "distanceType": 1,
+        "raceTrackId": 10010,
+        "slopes": [
+            {
+                "start": 20,
+                "length": 27,
+                "slope": -10299.886379843994
+            }
+        ],
+        "straights": [
+            {
+                "end": 500,
+                "start": 0
+            },
+            {
+                "end": 1200,
+                "start": 910
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "11002": {
+        "corners": [
+            {
+                "length": 205,
+                "start": 290
+            },
+            {
+                "length": 205,
+                "start": 495
+            },
+            {
+                "length": 205,
+                "start": 1100
+            },
+            {
+                "length": 205,
+                "start": 1305
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1800,
+        "distanceType": 2,
+        "raceTrackId": 10010,
+        "slopes": [
+            {
+                "start": 275,
+                "length": 11,
+                "slope": 10956.67588099179
+            },
+            {
+                "start": 437,
+                "length": 59,
+                "slope": 12204.441594237847
+            },
+            {
+                "start": 511,
+                "length": 15,
+                "slope": 14419.750198352393
+            }
+        ],
+        "straights": [
+            {
+                "end": 290,
+                "start": 0
+            },
+            {
+                "end": 1100,
+                "start": 700
+            },
+            {
+                "end": 1800,
+                "start": 1510
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "11003": {
+        "corners": [
+            {
+                "length": 205,
+                "start": 490
+            },
+            {
+                "length": 205,
+                "start": 695
+            },
+            {
+                "length": 205,
+                "start": 1300
+            },
+            {
+                "length": 205,
+                "start": 1505
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            3
+        ],
+        "distance": 2000,
+        "distanceType": 3,
+        "raceTrackId": 10010,
+        "slopes": [
+            {
+                "start": 485,
+                "length": 97,
+                "slope": 10897.74533524032
+            },
+            {
+                "start": 640,
+                "length": 60,
+                "slope": 12093.110581296105
+            },
+            {
+                "start": 716,
+                "length": 15,
+                "slope": 14484.093713570945
+            }
+        ],
+        "straights": [
+            {
+                "end": 490,
+                "start": 0
+            },
+            {
+                "end": 1300,
+                "start": 900
+            },
+            {
+                "end": 2000,
+                "start": 1710
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "11004": {
+        "corners": [
+            {
+                "length": 205,
+                "start": 309
+            },
+            {
+                "length": 205,
+                "start": 514
+            },
+            {
+                "length": 205,
+                "start": 1110
+            },
+            {
+                "length": 205,
+                "start": 1315
+            },
+            {
+                "length": 205,
+                "start": 1900
+            },
+            {
+                "length": 205,
+                "start": 2105
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            2
+        ],
+        "distance": 2600,
+        "distanceType": 4,
+        "raceTrackId": 10010,
+        "slopes": [
+            {
+                "start": 1101,
+                "length": 218,
+                "slope": 30217.5880531938
+            },
+            {
+                "start": 1332,
+                "length": 43,
+                "slope": 29875.391406280432
+            }
+        ],
+        "straights": [
+            {
+                "end": 309,
+                "start": 0
+            },
+            {
+                "end": 1110,
+                "start": 719
+            },
+            {
+                "end": 1900,
+                "start": 1520
+            },
+            {
+                "end": 2600,
+                "start": 2310
+            }
+        ],
+        "surface": 1,
+        "turn": 1
+    },
+    "11005": {
+        "corners": [
+            {
+                "length": 180,
+                "start": 360
+            },
+            {
+                "length": 180,
+                "start": 540
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [
+            1
+        ],
+        "distance": 1000,
+        "distanceType": 1,
+        "raceTrackId": 10010,
+        "slopes": [
+            {
+                "start": 373,
+                "length": 81,
+                "slope": -14127.566664722284
+            }
+        ],
+        "straights": [
+            {
+                "end": 360,
+                "start": 0
+            },
+            {
+                "end": 1000,
+                "start": 720
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "11006": {
+        "corners": [
+            {
+                "length": 180,
+                "start": 340
+            },
+            {
+                "length": 180,
+                "start": 520
+            },
+            {
+                "length": 180,
+                "start": 1060
+            },
+            {
+                "length": 180,
+                "start": 1240
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1700,
+        "distanceType": 2,
+        "raceTrackId": 10010,
+        "slopes": [
+            {
+                "start": 293,
+                "length": 179,
+                "slope": 18951.986973981617
+            },
+            {
+                "start": 561,
+                "length": 156,
+                "slope": -18899.514516704316
+            },
+            {
+                "start": 1060,
+                "length": 103,
+                "slope": -19541.02838433876
+            }
+        ],
+        "straights": [
+            {
+                "end": 340,
+                "start": 0
+            },
+            {
+                "end": 1060,
+                "start": 700
+            },
+            {
+                "end": 1700,
+                "start": 1420
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "11007": {
+        "corners": [
+            {
+                "length": 180,
+                "start": 312
+            },
+            {
+                "length": 180,
+                "start": 492
+            },
+            {
+                "length": 180,
+                "start": 1040
+            },
+            {
+                "length": 180,
+                "start": 1220
+            },
+            {
+                "length": 180,
+                "start": 1760
+            },
+            {
+                "length": 180,
+                "start": 1940
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 2400,
+        "distanceType": 3,
+        "raceTrackId": 10010,
+        "slopes": [
+            {
+                "start": 328,
+                "length": 47,
+                "slope": -10607.196867004299
+            },
+            {
+                "start": 1102,
+                "length": 79,
+                "slope": 14214.418158135502
+            },
+            {
+                "start": 1774,
+                "length": 47,
+                "slope": -10606.238880939414
+            }
+        ],
+        "straights": [
+            {
+                "end": 312,
+                "start": 0
+            },
+            {
+                "end": 1040,
+                "start": 672
+            },
+            {
+                "end": 1760,
+                "start": 1400
+            },
+            {
+                "end": 2400,
+                "start": 2120
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "11101": {
+        "corners": [
+            {
+                "length": 150,
+                "start": 500
+            },
+            {
+                "length": 150,
+                "start": 650
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1200,
+        "distanceType": 1,
+        "raceTrackId": 10101,
+        "slopes": [],
+        "straights": [
+            {
+                "end": 500,
+                "start": 0
+            },
+            {
+                "end": 1200,
+                "start": 812
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "11102": {
+        "corners": [
+            {
+                "length": 150,
+                "start": 300
+            },
+            {
+                "length": 150,
+                "start": 500
+            },
+            {
+                "length": 150,
+                "start": 1100
+            },
+            {
+                "length": 150,
+                "start": 1250
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 1800,
+        "distanceType": 2,
+        "raceTrackId": 10101,
+        "slopes": [],
+        "straights": [
+            {
+                "end": 301,
+                "start": 0
+            },
+            {
+                "end": 1100.23,
+                "start": 600
+            },
+            {
+                "end": 1800,
+                "start": 1400
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    },
+    "11103": {
+        "corners": [
+            {
+                "length": 150,
+                "start": 500
+            },
+            {
+                "length": 150,
+                "start": 650
+            },
+            {
+                "length": 150,
+                "start": 1300
+            },
+            {
+                "length": 150,
+                "start": 1450
+            }
+        ],
+        "course": 1,
+        "courseSetStatus": [],
+        "distance": 2000,
+        "distanceType": 3,
+        "raceTrackId": 10101,
+        "slopes": [],
+        "straights": [
+            {
+                "end": 500,
+                "start": 0
+            },
+            {
+                "end": 1300,
+                "start": 800
+            },
+            {
+                "end": 2000,
+                "start": 1600
+            }
+        ],
+        "surface": 2,
+        "turn": 1
+    }
+}


### PR DESCRIPTION
The Japanese version of Uma Umamusume has introduced uphill and downhill sections in the latest track update. The global version, however, is behind and should still be using the old track data.

I have adapted the slope logic for the global version based on the old Japanese version implementation ([uma-clock-emu/cfed5c](https://github.com/urakagi/uma-clock-emu/tree/3cfed5cc90e68c75a245dc7b12637acb207f7a92)).

Conversion logic can be found here: [slope.py](https://github.com/mikumifa/uma-tools/blob/b960955768b7a2682ea6ce8d982a57e9d0181dea/python/slope.py)

The slope of each track segment is calculated using the average value over the segment interval.


Slope Calculation Explanation:
In the conversion code, the slope of each track segment is calculated using the average value over the segment interval.

The reasoning is based on the original [implementation](https://github.com/urakagi/uma-clock-emu/blob/3cfed5cc90e68c75a245dc7b12637acb207f7a92/src/components/MixinRaceCore.vue#L188-L190):

```js

if (upSlope) {
    ret -= Math.abs(this.currentSlope) * 200.0 / this.modifiedPower;
}
```

Here, `200.0 / this.modifiedPower` is  a constant factor. Therefore, using the average slope over the interval produces an equivalent effect on speed, making the approximation valid.